### PR TITLE
Implement Reconciler component and add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Pre-commit hooks configuration
+# See https://pre-commit.com for more information
+
+repos:
+  - repo: local
+    hooks:
+      # Run linting (golangci-lint + arch-go + eventimmutability)
+      - id: make-lint
+        name: make lint
+        entry: make lint
+        language: system
+        pass_filenames: false
+        files: \.go$
+
+      # Run security audit (govulncheck)
+      - id: make-audit
+        name: make audit
+        entry: make audit
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -243,6 +243,30 @@ make docker-build
 make test-coverage
 ```
 
+### Pre-commit Hooks
+
+Automatic code quality checks can be set up using [pre-commit](https://pre-commit.com/):
+
+```bash
+# Install pre-commit (one-time setup)
+pip install pre-commit
+# or: brew install pre-commit
+
+# Install git hooks (one-time per repository clone)
+pre-commit install
+
+# Hooks now run automatically on git commit
+git commit -m "my changes"  # Runs make lint && make audit
+
+# Skip hooks if needed (e.g., for WIP commits)
+git commit --no-verify -m "WIP"
+
+# Run hooks manually on all files
+pre-commit run --all-files
+```
+
+The hooks will automatically run `make lint` and `make audit` before each commit, catching issues early.
+
 ## Contributing
 
 Contributions are welcome!

--- a/docs/development/linting.md
+++ b/docs/development/linting.md
@@ -167,6 +167,133 @@ jobs:
         run: make audit
 ```
 
+## Pre-commit Hooks
+
+The project supports automatic linting and auditing before each commit using [pre-commit](https://pre-commit.com/).
+
+### Setup
+
+Install the pre-commit framework (one-time):
+
+```bash
+# Using pip
+pip install pre-commit
+
+# Using Homebrew (macOS/Linux)
+brew install pre-commit
+
+# Using conda
+conda install -c conda-forge pre-commit
+```
+
+Install the git hooks (one-time per repository clone):
+
+```bash
+pre-commit install
+```
+
+### Usage
+
+Once installed, pre-commit automatically runs before each `git commit`:
+
+```bash
+# Hooks run automatically
+git commit -m "Add new feature"
+
+# Output example:
+# make lint........................................Passed
+# make audit.......................................Passed
+# [main abc1234] Add new feature
+```
+
+If any hook fails, the commit is blocked until issues are fixed:
+
+```bash
+# Hooks detect issues
+git commit -m "Add feature with linting issues"
+
+# Output example:
+# make lint........................................Failed
+# - hook id: make-lint
+# - exit code: 1
+#
+# [golangci-lint output showing errors]
+
+# Fix issues, then commit again
+make lint-fix  # Auto-fix where possible
+git add .
+git commit -m "Add feature with linting issues"
+```
+
+### Bypassing Hooks
+
+Sometimes you need to commit without running hooks (e.g., for WIP commits):
+
+```bash
+# Skip all hooks
+git commit --no-verify -m "WIP: work in progress"
+
+# Skip specific hook
+SKIP=make-audit git commit -m "Skip audit for this commit"
+```
+
+### Manual Execution
+
+Run hooks manually without committing:
+
+```bash
+# Run all hooks on all files
+pre-commit run --all-files
+
+# Run specific hook
+pre-commit run make-lint --all-files
+
+# Run on staged files only (default)
+pre-commit run
+```
+
+### Configuration
+
+The pre-commit configuration is defined in `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: make-lint
+        name: make lint
+        entry: make lint
+        language: system
+        pass_filenames: false
+        files: \.go$
+
+      - id: make-audit
+        name: make audit
+        entry: make audit
+        language: system
+        pass_filenames: false
+        always_run: true
+```
+
+The configuration uses local hooks that execute the existing `make lint` and `make audit` targets, ensuring consistency with CI and manual workflows.
+
+### Troubleshooting
+
+**Hook doesn't run on commit**
+- Verify installation: `pre-commit --version`
+- Reinstall hooks: `pre-commit install`
+- Check `.git/hooks/pre-commit` exists
+
+**Slow hook execution**
+- Use `SKIP=make-audit` to skip security scanning for quick commits
+- Run `make audit` separately or in CI
+- Pre-commit caches results for unchanged files
+
+**Hook fails but manual `make lint` passes**
+- Ensure working directory is clean: `git status`
+- Run `pre-commit run --all-files` to see full output
+- Check if pre-commit is using correct Go version
+
 ## Common Issues
 
 ### Fixing Format Issues

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -1,0 +1,250 @@
+// Copyright 2025 Philipp Hossner
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package reconciler implements the Reconciler component that debounces resource
+// changes and triggers reconciliation events.
+//
+// The Reconciler is a key component in Stage 5 of the controller startup sequence.
+// It subscribes to resource change events, applies debouncing to batch rapid changes,
+// and publishes reconciliation trigger events when the system reaches a quiet state.
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"haproxy-template-ic/pkg/controller/events"
+	busevents "haproxy-template-ic/pkg/events"
+)
+
+const (
+	// DefaultDebounceInterval is the default time to wait after the last resource
+	// change before triggering reconciliation.
+	DefaultDebounceInterval = 500 * time.Millisecond
+
+	// EventBufferSize is the size of the event subscription buffer.
+	EventBufferSize = 100
+)
+
+// Reconciler implements the reconciliation debouncer component.
+//
+// It subscribes to resource change events and configuration change events,
+// applies debouncing logic to prevent excessive reconciliations, and triggers
+// reconciliation when appropriate.
+//
+// Debouncing behavior:
+//   - Resource changes: Wait for quiet period (debounce interval) before triggering
+//   - Config changes: Trigger immediately (no debouncing)
+//
+// The component publishes ReconciliationTriggeredEvent to signal the Executor
+// to begin a reconciliation cycle.
+type Reconciler struct {
+	eventBus          *busevents.EventBus
+	logger            *slog.Logger
+	debounceInterval  time.Duration
+	debounceTimer     *time.Timer
+	pendingTrigger    bool
+	lastTriggerReason string
+}
+
+// Config configures the Reconciler component.
+type Config struct {
+	// DebounceInterval is the time to wait after the last resource change
+	// before triggering reconciliation. If not set, DefaultDebounceInterval is used.
+	DebounceInterval time.Duration
+}
+
+// New creates a new Reconciler component.
+//
+// Parameters:
+//   - eventBus: The EventBus for subscribing to events and publishing triggers
+//   - logger: Structured logger for component logging
+//   - config: Optional configuration (nil for defaults)
+//
+// Returns:
+//   - A new Reconciler instance ready to be started
+func New(eventBus *busevents.EventBus, logger *slog.Logger, config *Config) *Reconciler {
+	debounceInterval := DefaultDebounceInterval
+	if config != nil && config.DebounceInterval > 0 {
+		debounceInterval = config.DebounceInterval
+	}
+
+	return &Reconciler{
+		eventBus:         eventBus,
+		logger:           logger,
+		debounceInterval: debounceInterval,
+		// Timer is created on first use to avoid firing immediately
+		debounceTimer:     nil,
+		pendingTrigger:    false,
+		lastTriggerReason: "",
+	}
+}
+
+// Start begins the reconciler's event loop.
+//
+// This method blocks until the context is cancelled or an error occurs.
+// It subscribes to the EventBus and processes events:
+//   - ResourceIndexUpdatedEvent: Starts/resets debounce timer
+//   - ConfigValidatedEvent: Triggers immediate reconciliation
+//   - Debounce timer expiration: Publishes ReconciliationTriggeredEvent
+//
+// The component runs until the context is cancelled, at which point it
+// performs cleanup and returns.
+//
+// Parameters:
+//   - ctx: Context for cancellation and lifecycle management
+//
+// Returns:
+//   - nil when context is cancelled (graceful shutdown)
+//   - Error only in exceptional circumstances
+func (r *Reconciler) Start(ctx context.Context) error {
+	r.logger.Info("Reconciler starting",
+		"debounce_interval", r.debounceInterval)
+
+	eventChan := r.eventBus.Subscribe(EventBufferSize)
+
+	for {
+		select {
+		case event := <-eventChan:
+			r.handleEvent(event)
+
+		case <-r.getDebounceTimerChan():
+			// Debounce timer expired - trigger reconciliation
+			r.triggerReconciliation("debounce_timer")
+
+		case <-ctx.Done():
+			r.logger.Info("Reconciler shutting down", "reason", ctx.Err())
+			r.cleanup()
+			return nil
+		}
+	}
+}
+
+// handleEvent processes events from the EventBus.
+func (r *Reconciler) handleEvent(event busevents.Event) {
+	switch e := event.(type) {
+	case *events.ResourceIndexUpdatedEvent:
+		r.handleResourceChange(e)
+
+	case *events.ConfigValidatedEvent:
+		r.handleConfigChange(e)
+	}
+}
+
+// handleResourceChange processes resource index update events.
+//
+// Resource changes are debounced to batch rapid successive changes.
+// The debounce timer is reset on each change, and reconciliation is
+// only triggered after a quiet period.
+func (r *Reconciler) handleResourceChange(event *events.ResourceIndexUpdatedEvent) {
+	// Skip initial sync events - we don't want to trigger reconciliation
+	// until the initial sync is complete
+	if event.ChangeStats.IsInitialSync {
+		r.logger.Debug("Skipping initial sync event",
+			"resource_type", event.ResourceTypeName,
+			"created", event.ChangeStats.Created,
+			"modified", event.ChangeStats.Modified,
+			"deleted", event.ChangeStats.Deleted)
+		return
+	}
+
+	r.logger.Debug("Resource change detected, resetting debounce timer",
+		"resource_type", event.ResourceTypeName,
+		"created", event.ChangeStats.Created,
+		"modified", event.ChangeStats.Modified,
+		"deleted", event.ChangeStats.Deleted,
+		"debounce_interval", r.debounceInterval)
+
+	r.pendingTrigger = true
+	r.lastTriggerReason = "resource_change"
+	r.resetDebounceTimer()
+}
+
+// handleConfigChange processes configuration validation events.
+//
+// Config changes trigger immediate reconciliation without debouncing,
+// as configuration updates are infrequent and require prompt action.
+func (r *Reconciler) handleConfigChange(event *events.ConfigValidatedEvent) {
+	r.logger.Info("Configuration change detected, triggering immediate reconciliation",
+		"config_version", event.Version,
+		"secret_version", event.SecretVersion)
+
+	r.stopDebounceTimer()
+	r.pendingTrigger = false
+	r.triggerReconciliation("config_change")
+}
+
+// resetDebounceTimer resets the debounce timer to the configured interval.
+func (r *Reconciler) resetDebounceTimer() {
+	if r.debounceTimer == nil {
+		// Create timer on first use
+		r.debounceTimer = time.NewTimer(r.debounceInterval)
+	} else {
+		// Stop and drain existing timer before resetting
+		if !r.debounceTimer.Stop() {
+			// Timer already fired, drain the channel
+			select {
+			case <-r.debounceTimer.C:
+			default:
+			}
+		}
+		r.debounceTimer.Reset(r.debounceInterval)
+	}
+}
+
+// stopDebounceTimer stops the debounce timer if it's running.
+func (r *Reconciler) stopDebounceTimer() {
+	if r.debounceTimer != nil {
+		if !r.debounceTimer.Stop() {
+			// Timer already fired, drain the channel
+			select {
+			case <-r.debounceTimer.C:
+			default:
+			}
+		}
+	}
+	r.pendingTrigger = false
+}
+
+// getDebounceTimerChan returns the debounce timer's channel or a nil channel
+// if the timer hasn't been created yet.
+//
+// This allows the select statement to work correctly - a nil channel blocks forever,
+// which is the desired behavior when there's no active debounce timer.
+func (r *Reconciler) getDebounceTimerChan() <-chan time.Time {
+	if r.debounceTimer == nil {
+		return nil
+	}
+	return r.debounceTimer.C
+}
+
+// triggerReconciliation publishes a ReconciliationTriggeredEvent.
+func (r *Reconciler) triggerReconciliation(reason string) {
+	r.logger.Info("Triggering reconciliation", "reason", reason)
+
+	r.eventBus.Publish(events.NewReconciliationTriggeredEvent(reason))
+	r.pendingTrigger = false
+}
+
+// cleanup performs cleanup when the component is shutting down.
+func (r *Reconciler) cleanup() {
+	r.stopDebounceTimer()
+
+	// If there was a pending trigger when we shut down, log it
+	if r.pendingTrigger {
+		r.logger.Debug("Reconciler shutting down with pending trigger",
+			"last_reason", r.lastTriggerReason)
+	}
+}

--- a/pkg/controller/reconciler/reconciler_test.go
+++ b/pkg/controller/reconciler/reconciler_test.go
@@ -1,0 +1,429 @@
+// Copyright 2025 Philipp Hossner
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"haproxy-template-ic/pkg/controller/events"
+	busevents "haproxy-template-ic/pkg/events"
+	"haproxy-template-ic/pkg/k8s/types"
+)
+
+// TestReconciler_DebounceResourceChanges tests that resource changes are properly debounced.
+func TestReconciler_DebounceResourceChanges(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Use short debounce interval for faster tests
+	config := &Config{
+		DebounceInterval: 100 * time.Millisecond,
+	}
+
+	reconciler := New(bus, logger, config)
+
+	// Subscribe to reconciliation triggered events
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start reconciler in background
+	go reconciler.Start(ctx)
+
+	// Give the reconciler time to start listening
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish a resource change event (not initial sync)
+	bus.Publish(events.NewResourceIndexUpdatedEvent("ingresses", types.ChangeStats{
+		Created:       1,
+		Modified:      0,
+		Deleted:       0,
+		IsInitialSync: false,
+	}))
+
+	// Wait for debounce timer to expire and reconciliation to trigger
+	timeout := time.After(500 * time.Millisecond)
+	var receivedEvent *events.ReconciliationTriggeredEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+				receivedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for ReconciliationTriggeredEvent")
+		}
+	}
+
+Done:
+	require.NotNil(t, receivedEvent, "Should receive ReconciliationTriggeredEvent")
+	assert.Equal(t, "debounce_timer", receivedEvent.Reason)
+}
+
+// TestReconciler_MultipleChangesResetDebounce tests that multiple changes reset the debounce timer.
+func TestReconciler_MultipleChangesResetDebounce(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	config := &Config{
+		DebounceInterval: 200 * time.Millisecond,
+	}
+
+	reconciler := New(bus, logger, config)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go reconciler.Start(ctx)
+
+	// Give the reconciler time to start listening
+	time.Sleep(50 * time.Millisecond)
+
+	// Start timing from here to measure total delay
+	startTime := time.Now()
+
+	// Publish first change
+	bus.Publish(events.NewResourceIndexUpdatedEvent("ingresses", types.ChangeStats{
+		Created:       1,
+		IsInitialSync: false,
+	}))
+
+	// Wait 100ms (half of debounce interval)
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish second change - this should reset the timer
+	bus.Publish(events.NewResourceIndexUpdatedEvent("services", types.ChangeStats{
+		Modified:      1,
+		IsInitialSync: false,
+	}))
+
+	// Now wait for debounce to complete (200ms from second event)
+	// Total time: 100ms + 200ms = 300ms
+	timeout := time.After(400 * time.Millisecond)
+	var receivedEvent *events.ReconciliationTriggeredEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+				receivedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for ReconciliationTriggeredEvent")
+		}
+	}
+
+Done:
+	elapsed := time.Since(startTime)
+
+	require.NotNil(t, receivedEvent)
+	assert.Equal(t, "debounce_timer", receivedEvent.Reason)
+
+	// Should take at least 250ms (100ms wait + 200ms debounce, with some tolerance)
+	assert.Greater(t, elapsed, 250*time.Millisecond,
+		"Reconciliation should be delayed by the full debounce interval after the second change")
+}
+
+// TestReconciler_ConfigChangeImmediateTrigger tests that config changes trigger immediately.
+func TestReconciler_ConfigChangeImmediateTrigger(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	config := &Config{
+		DebounceInterval: 500 * time.Millisecond, // Long interval
+	}
+
+	reconciler := New(bus, logger, config)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go reconciler.Start(ctx)
+
+	// Give the reconciler time to start listening
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish config change event
+	bus.Publish(events.NewConfigValidatedEvent(nil, "v1", "s1"))
+
+	// Should trigger immediately (within 100ms, not after 500ms debounce)
+	timeout := time.After(200 * time.Millisecond)
+	var receivedEvent *events.ReconciliationTriggeredEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+				receivedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for ReconciliationTriggeredEvent")
+		}
+	}
+
+Done:
+	require.NotNil(t, receivedEvent)
+	assert.Equal(t, "config_change", receivedEvent.Reason)
+}
+
+// TestReconciler_SkipInitialSyncEvents tests that initial sync events don't trigger reconciliation.
+func TestReconciler_SkipInitialSyncEvents(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	config := &Config{
+		DebounceInterval: 100 * time.Millisecond,
+	}
+
+	reconciler := New(bus, logger, config)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go reconciler.Start(ctx)
+
+	// Publish initial sync events
+	bus.Publish(events.NewResourceIndexUpdatedEvent("ingresses", types.ChangeStats{
+		Created:       10,
+		IsInitialSync: true,
+	}))
+
+	bus.Publish(events.NewResourceIndexUpdatedEvent("services", types.ChangeStats{
+		Created:       5,
+		IsInitialSync: true,
+	}))
+
+	// Wait longer than debounce interval
+	time.Sleep(300 * time.Millisecond)
+
+	// Should NOT receive any reconciliation triggered events
+	select {
+	case event := <-eventChan:
+		if _, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+			t.Fatal("Should not trigger reconciliation for initial sync events")
+		}
+	default:
+		// Expected - no events
+	}
+}
+
+// TestReconciler_ConfigCancelsDebounce tests that config changes cancel pending debounce.
+func TestReconciler_ConfigCancelsDebounce(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	config := &Config{
+		DebounceInterval: 300 * time.Millisecond,
+	}
+
+	reconciler := New(bus, logger, config)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go reconciler.Start(ctx)
+
+	// Publish resource change (starts debounce timer)
+	bus.Publish(events.NewResourceIndexUpdatedEvent("ingresses", types.ChangeStats{
+		Created:       1,
+		IsInitialSync: false,
+	}))
+
+	// Wait a bit but not long enough for debounce
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish config change (should trigger immediately and cancel debounce)
+	bus.Publish(events.NewConfigValidatedEvent(nil, "v2", "s2"))
+
+	// Should receive config_change trigger quickly
+	timeout := time.After(200 * time.Millisecond)
+	var receivedEvents []*events.ReconciliationTriggeredEvent
+
+Loop:
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+				receivedEvents = append(receivedEvents, e)
+			}
+		case <-timeout:
+			break Loop
+		}
+	}
+
+	// Should only receive one event (config_change), not the debounced resource_change
+	require.Len(t, receivedEvents, 1, "Should only receive one reconciliation trigger")
+	assert.Equal(t, "config_change", receivedEvents[0].Reason)
+}
+
+// TestReconciler_ContextCancellation tests graceful shutdown on context cancellation.
+func TestReconciler_ContextCancellation(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	reconciler := New(bus, logger, nil)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start reconciler
+	done := make(chan error, 1)
+	go func() {
+		done <- reconciler.Start(ctx)
+	}()
+
+	// Publish a resource change to start debounce
+	bus.Publish(events.NewResourceIndexUpdatedEvent("ingresses", types.ChangeStats{
+		Created:       1,
+		IsInitialSync: false,
+	}))
+
+	// Cancel context before debounce expires
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Should return quickly
+	timeout := time.After(1 * time.Second)
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Start should return nil on context cancellation")
+	case <-timeout:
+		t.Fatal("Reconciler did not shut down within timeout")
+	}
+
+	// Should not have triggered reconciliation
+	select {
+	case event := <-eventChan:
+		if _, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+			t.Fatal("Should not trigger reconciliation after context cancellation")
+		}
+	default:
+		// Expected - no reconciliation event
+	}
+}
+
+// TestReconciler_CustomDebounceInterval tests using a custom debounce interval.
+func TestReconciler_CustomDebounceInterval(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	customInterval := 150 * time.Millisecond
+	config := &Config{
+		DebounceInterval: customInterval,
+	}
+
+	reconciler := New(bus, logger, config)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go reconciler.Start(ctx)
+
+	// Give the reconciler time to start listening
+	time.Sleep(50 * time.Millisecond)
+
+	startTime := time.Now()
+
+	// Publish resource change
+	bus.Publish(events.NewResourceIndexUpdatedEvent("ingresses", types.ChangeStats{
+		Created:       1,
+		IsInitialSync: false,
+	}))
+
+	// Wait for reconciliation
+	timeout := time.After(500 * time.Millisecond)
+	var receivedEvent *events.ReconciliationTriggeredEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+				receivedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for ReconciliationTriggeredEvent")
+		}
+	}
+
+Done:
+	elapsed := time.Since(startTime)
+
+	require.NotNil(t, receivedEvent)
+	assert.Equal(t, "debounce_timer", receivedEvent.Reason)
+
+	// Verify timing is approximately correct (with tolerance)
+	assert.Greater(t, elapsed, customInterval-10*time.Millisecond,
+		"Should wait at least the custom debounce interval")
+	assert.Less(t, elapsed, customInterval+100*time.Millisecond,
+		"Should not wait significantly longer than the custom debounce interval")
+}
+
+// TestReconciler_DefaultConfig tests using default configuration.
+func TestReconciler_DefaultConfig(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Pass nil config to use defaults
+	reconciler := New(bus, logger, nil)
+
+	assert.Equal(t, DefaultDebounceInterval, reconciler.debounceInterval,
+		"Should use default debounce interval when config is nil")
+}
+
+// TestReconciler_ZeroDebounceUsesDefault tests that zero debounce interval falls back to default.
+func TestReconciler_ZeroDebounceUsesDefault(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	config := &Config{
+		DebounceInterval: 0, // Invalid - should use default
+	}
+
+	reconciler := New(bus, logger, config)
+
+	assert.Equal(t, DefaultDebounceInterval, reconciler.debounceInterval,
+		"Should use default debounce interval when config value is zero")
+}


### PR DESCRIPTION
This PR implements the Stage 5 Reconciler component and adds automated code quality checks via pre-commit hooks.

## Reconciler Component

Implements the first Stage 5 reconciliation component that debounces resource changes and triggers reconciliation events.

**Key Features:**
- Debouncing logic for resource changes (configurable, default 500ms)
- Immediate triggers for configuration changes (no debouncing)
- Filters initial sync events to prevent premature reconciliation
- Graceful shutdown with proper cleanup
- Comprehensive unit tests (9 test cases, all passing)

**Implementation:**
- `pkg/controller/reconciler/reconciler.go` (250 lines)
- `pkg/controller/reconciler/reconciler_test.go` (429 lines)
- Integrated into `controller.go` Stage 5 startup

The Reconciler subscribes to `ResourceIndexUpdatedEvent` and `ConfigValidatedEvent`, applies appropriate debouncing logic, and publishes `ReconciliationTriggeredEvent` when ready.

## Pre-commit Hooks

Adds automated linting and security scanning before each commit using the pre-commit framework.

**Implementation:**
- `.pre-commit-config.yaml` - Runs `make lint` and `make audit`
- Comprehensive setup documentation in README.md and docs/development/linting.md
- Leverages existing Makefile targets for consistency with CI

**Developer Experience:**
```bash
# One-time setup
pip install pre-commit
pre-commit install

# Automatic on commit
git commit -m "changes"  # Runs make lint && make audit

# Skip when needed
git commit --no-verify -m "WIP"
```

## Documentation Updates

- Updated `docs/development/design.md` with Stage 5 architecture
- Added Reconciler component descriptions
- Fixed event type definitions to match implementation
- Added comprehensive pre-commit hooks documentation

## Testing

- All 9 reconciler unit tests pass
- All existing controller tests pass (12 test suites)
- Code builds without errors
- Passes `go vet` checks
- Pre-commit hooks validated on this commit