### PR TITLE
Implement Renderer component for template-based HAProxy configuration

### DIFF
--- a/pkg/controller/commentator/commentator.go
+++ b/pkg/controller/commentator/commentator.go
@@ -316,8 +316,8 @@ func (ec *EventCommentator) generateInsight(event busevents.Event) (insight stri
 			append(attrs, "config_bytes", e.ConfigBytes, "aux_files", e.AuxiliaryFileCount, "duration_ms", e.DurationMs)
 
 	case *events.TemplateRenderFailedEvent:
-		return fmt.Sprintf("Template rendering failed: %s", e.Error),
-			append(attrs, "error", e.Error)
+		return fmt.Sprintf("Template rendering failed for '%s': %s", e.TemplateName, e.Error),
+			append(attrs, "template", e.TemplateName, "error", e.Error)
 
 	// Validation Events
 	case *events.ValidationStartedEvent:

--- a/pkg/controller/renderer/component.go
+++ b/pkg/controller/renderer/component.go
@@ -1,0 +1,266 @@
+// Copyright 2025 Philipp Hossner
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package renderer implements the Renderer component that renders HAProxy
+// configuration and auxiliary files from templates.
+//
+// The Renderer is a Stage 5 component that subscribes to reconciliation
+// trigger events, builds rendering context from resource stores, and publishes
+// rendered output events for the next phase (validation/deployment).
+package renderer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"haproxy-template-ic/pkg/controller/events"
+	"haproxy-template-ic/pkg/core/config"
+	"haproxy-template-ic/pkg/dataplane"
+	"haproxy-template-ic/pkg/dataplane/auxiliaryfiles"
+	busevents "haproxy-template-ic/pkg/events"
+	"haproxy-template-ic/pkg/k8s/types"
+	"haproxy-template-ic/pkg/templating"
+)
+
+const (
+	// EventBufferSize is the size of the event subscription buffer.
+	EventBufferSize = 50
+)
+
+// Component implements the renderer component.
+//
+// It subscribes to ReconciliationTriggeredEvent, renders all templates
+// using the template engine and resource stores, and publishes the results
+// via TemplateRenderedEvent or TemplateRenderFailedEvent.
+type Component struct {
+	eventBus *busevents.EventBus
+	engine   *templating.TemplateEngine
+	config   *config.Config
+	stores   map[string]types.Store
+	logger   *slog.Logger
+}
+
+// New creates a new Renderer component.
+//
+// The component pre-compiles all templates during initialization for optimal
+// runtime performance.
+//
+// Parameters:
+//   - eventBus: The EventBus for subscribing to events and publishing results
+//   - config: Controller configuration containing templates
+//   - stores: Map of resource type names to their stores (e.g., "ingresses" -> Store)
+//   - logger: Structured logger for component logging
+//
+// Returns:
+//   - A new Component instance ready to be started
+//   - Error if template compilation fails
+func New(
+	eventBus *busevents.EventBus,
+	config *config.Config,
+	stores map[string]types.Store,
+	logger *slog.Logger,
+) (*Component, error) {
+	// Extract all templates from config
+	templates := extractTemplates(config)
+
+	// Pre-compile all templates
+	engine, err := templating.New(templating.EngineTypeGonja, templates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create template engine: %w", err)
+	}
+
+	return &Component{
+		eventBus: eventBus,
+		engine:   engine,
+		config:   config,
+		stores:   stores,
+		logger:   logger,
+	}, nil
+}
+
+// Start begins the renderer's event loop.
+//
+// This method blocks until the context is cancelled or an error occurs.
+// It subscribes to the EventBus and processes events:
+//   - ReconciliationTriggeredEvent: Starts template rendering
+//
+// The component runs until the context is cancelled, at which point it
+// performs cleanup and returns.
+//
+// Parameters:
+//   - ctx: Context for cancellation and lifecycle management
+//
+// Returns:
+//   - nil when context is cancelled (graceful shutdown)
+//   - Error only in exceptional circumstances
+func (c *Component) Start(ctx context.Context) error {
+	c.logger.Info("Renderer starting")
+
+	eventChan := c.eventBus.Subscribe(EventBufferSize)
+
+	for {
+		select {
+		case event := <-eventChan:
+			c.handleEvent(event)
+
+		case <-ctx.Done():
+			c.logger.Info("Renderer shutting down", "reason", ctx.Err())
+			return nil
+		}
+	}
+}
+
+// handleEvent processes events from the EventBus.
+func (c *Component) handleEvent(event busevents.Event) {
+	if ev, ok := event.(*events.ReconciliationTriggeredEvent); ok {
+		c.handleReconciliationTriggered(ev)
+	}
+}
+
+// handleReconciliationTriggered renders all templates when reconciliation is triggered.
+func (c *Component) handleReconciliationTriggered(event *events.ReconciliationTriggeredEvent) {
+	startTime := time.Now()
+
+	c.logger.Info("Template rendering triggered", "reason", event.Reason)
+
+	// Build rendering context from all resource stores
+	context := c.buildRenderingContext()
+
+	// Render main HAProxy configuration
+	haproxyConfig, err := c.engine.Render("haproxy.cfg", context)
+	if err != nil {
+		c.publishRenderFailure("haproxy.cfg", err)
+		return
+	}
+
+	// Render all auxiliary files
+	auxiliaryFiles, err := c.renderAuxiliaryFiles(context)
+	if err != nil {
+		// Error already published by renderAuxiliaryFiles
+		return
+	}
+
+	// Calculate metrics
+	durationMs := time.Since(startTime).Milliseconds()
+	auxFileCount := len(auxiliaryFiles.MapFiles) +
+		len(auxiliaryFiles.GeneralFiles) +
+		len(auxiliaryFiles.SSLCertificates)
+
+	c.logger.Info("Template rendering completed",
+		"config_bytes", len(haproxyConfig),
+		"auxiliary_files", auxFileCount,
+		"duration_ms", durationMs)
+
+	// Publish success event with rendered content
+	c.eventBus.Publish(events.NewTemplateRenderedEvent(
+		haproxyConfig,
+		auxiliaryFiles,
+		auxFileCount,
+		durationMs,
+	))
+}
+
+// renderAuxiliaryFiles renders all auxiliary files (maps, general files, SSL certificates).
+func (c *Component) renderAuxiliaryFiles(context map[string]interface{}) (*dataplane.AuxiliaryFiles, error) {
+	auxFiles := &dataplane.AuxiliaryFiles{}
+
+	// Render map files
+	for name := range c.config.Maps {
+		rendered, err := c.engine.Render(name, context)
+		if err != nil {
+			c.publishRenderFailure(name, err)
+			return nil, err
+		}
+
+		auxFiles.MapFiles = append(auxFiles.MapFiles, auxiliaryfiles.MapFile{
+			Path:    name,
+			Content: rendered,
+		})
+	}
+
+	// Render general files
+	for name := range c.config.Files {
+		rendered, err := c.engine.Render(name, context)
+		if err != nil {
+			c.publishRenderFailure(name, err)
+			return nil, err
+		}
+
+		auxFiles.GeneralFiles = append(auxFiles.GeneralFiles, auxiliaryfiles.GeneralFile{
+			Filename: name,
+			Content:  rendered,
+		})
+	}
+
+	// Render SSL certificates
+	for name := range c.config.SSLCertificates {
+		rendered, err := c.engine.Render(name, context)
+		if err != nil {
+			c.publishRenderFailure(name, err)
+			return nil, err
+		}
+
+		auxFiles.SSLCertificates = append(auxFiles.SSLCertificates, auxiliaryfiles.SSLCertificate{
+			Path:    name,
+			Content: rendered,
+		})
+	}
+
+	return auxFiles, nil
+}
+
+// publishRenderFailure publishes a template render failure event.
+func (c *Component) publishRenderFailure(templateName string, err error) {
+	c.logger.Error("Template rendering failed",
+		"template", templateName,
+		"error", err)
+
+	c.eventBus.Publish(events.NewTemplateRenderFailedEvent(
+		templateName,
+		err.Error(),
+		"", // Stack trace could be added here if needed
+	))
+}
+
+// extractTemplates converts config templates to map for engine initialization.
+func extractTemplates(cfg *config.Config) map[string]string {
+	templates := make(map[string]string)
+
+	// Main HAProxy config
+	templates["haproxy.cfg"] = cfg.HAProxyConfig.Template
+
+	// Template snippets
+	for name, snippet := range cfg.TemplateSnippets {
+		templates[name] = snippet.Template
+	}
+
+	// Map files
+	for name, mapDef := range cfg.Maps {
+		templates[name] = mapDef.Template
+	}
+
+	// General files
+	for name, fileDef := range cfg.Files {
+		templates[name] = fileDef.Template
+	}
+
+	// SSL certificates
+	for name, certDef := range cfg.SSLCertificates {
+		templates[name] = certDef.Template
+	}
+
+	return templates
+}

--- a/pkg/controller/renderer/component_test.go
+++ b/pkg/controller/renderer/component_test.go
@@ -1,0 +1,624 @@
+// Copyright 2025 Philipp Hossner
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"haproxy-template-ic/pkg/controller/events"
+	"haproxy-template-ic/pkg/core/config"
+	busevents "haproxy-template-ic/pkg/events"
+	"haproxy-template-ic/pkg/k8s/types"
+)
+
+// mockStore implements types.Store for testing.
+type mockStore struct {
+	items []interface{}
+}
+
+func (m *mockStore) Add(resource interface{}, keys []string) error {
+	m.items = append(m.items, resource)
+	return nil
+}
+
+func (m *mockStore) Update(resource interface{}, keys []string) error {
+	return nil
+}
+
+func (m *mockStore) Delete(keys ...string) error {
+	return nil
+}
+
+func (m *mockStore) List() ([]interface{}, error) {
+	return m.items, nil
+}
+
+func (m *mockStore) Get(keys ...string) ([]interface{}, error) {
+	return nil, nil
+}
+
+func (m *mockStore) Clear() error {
+	m.items = nil
+	return nil
+}
+
+// TestNew_Success tests successful renderer creation with valid configuration.
+func TestNew_Success(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: "global\n    daemon\n",
+		},
+		Maps: map[string]config.MapFile{
+			"domain.map": {Template: "example.com backend1\n"},
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": &mockStore{},
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+
+	require.NoError(t, err)
+	assert.NotNil(t, renderer)
+	assert.NotNil(t, renderer.engine)
+	assert.Equal(t, cfg, renderer.config)
+	assert.Equal(t, stores, renderer.stores)
+}
+
+// TestNew_InvalidTemplate tests renderer creation with invalid template syntax.
+func TestNew_InvalidTemplate(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: "global\n{{ unclosed tag\n",
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": &mockStore{},
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+
+	assert.Error(t, err)
+	assert.Nil(t, renderer)
+	assert.Contains(t, err.Error(), "failed to create template engine")
+}
+
+// TestRenderer_SuccessfulRendering tests successful template rendering.
+func TestRenderer_SuccessfulRendering(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: `global
+    daemon
+
+defaults
+    mode http
+
+{% for ingress in resources.ingresses %}
+# Ingress: {{ ingress.metadata.name }}
+{% endfor %}
+`,
+		},
+	}
+
+	// Create mock store with sample ingress
+	ingressStore := &mockStore{
+		items: []interface{}{
+			map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test-ingress",
+					"namespace": "default",
+				},
+			},
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": ingressStore,
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	// Subscribe to events
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start renderer
+	go renderer.Start(ctx)
+
+	// Give renderer time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Trigger reconciliation
+	bus.Publish(events.NewReconciliationTriggeredEvent("test"))
+
+	// Wait for rendered event
+	timeout := time.After(1 * time.Second)
+	var renderedEvent *events.TemplateRenderedEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.TemplateRenderedEvent); ok {
+				renderedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for TemplateRenderedEvent")
+		}
+	}
+
+Done:
+	require.NotNil(t, renderedEvent)
+	assert.Contains(t, renderedEvent.HAProxyConfig, "global")
+	assert.Contains(t, renderedEvent.HAProxyConfig, "# Ingress: test-ingress")
+	assert.Greater(t, renderedEvent.ConfigBytes, 0)
+	assert.GreaterOrEqual(t, renderedEvent.DurationMs, int64(0))
+}
+
+// TestRenderer_WithAuxiliaryFiles tests rendering with maps, files, and SSL certificates.
+func TestRenderer_WithAuxiliaryFiles(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: "global\n    daemon\n",
+		},
+		Maps: map[string]config.MapFile{
+			"domains.map": {
+				Template: "{% for ingress in resources.ingresses %}{{ ingress.metadata.name }}.example.com backend1\n{% endfor %}",
+			},
+		},
+		Files: map[string]config.GeneralFile{
+			"error-500.http": {
+				Template: "HTTP/1.0 500 Internal Server Error\nContent-Type: text/html\n\n<h1>Error 500</h1>\n",
+			},
+		},
+		SSLCertificates: map[string]config.SSLCertificate{
+			"example.pem": {
+				Template: "-----BEGIN CERTIFICATE-----\ntest-cert-data\n-----END CERTIFICATE-----\n",
+			},
+		},
+	}
+
+	ingressStore := &mockStore{
+		items: []interface{}{
+			map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test-ingress",
+				},
+			},
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": ingressStore,
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go renderer.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	bus.Publish(events.NewReconciliationTriggeredEvent("test"))
+
+	timeout := time.After(1 * time.Second)
+	var renderedEvent *events.TemplateRenderedEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.TemplateRenderedEvent); ok {
+				renderedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for TemplateRenderedEvent")
+		}
+	}
+
+Done:
+	require.NotNil(t, renderedEvent)
+	assert.Equal(t, 3, renderedEvent.AuxiliaryFileCount, "Should have 1 map + 1 file + 1 SSL cert")
+
+	// Verify auxiliary files are populated
+	assert.NotNil(t, renderedEvent.AuxiliaryFiles)
+}
+
+// TestRenderer_RenderFailure tests handling of template rendering failures.
+func TestRenderer_RenderFailure(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: "global\n    daemon\n",
+		},
+		Maps: map[string]config.MapFile{
+			"broken.map": {
+				// Template references non-existent function
+				Template: "{{ undefined_function() }}",
+			},
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": &mockStore{},
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go renderer.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	bus.Publish(events.NewReconciliationTriggeredEvent("test"))
+
+	timeout := time.After(1 * time.Second)
+	var failureEvent *events.TemplateRenderFailedEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.TemplateRenderFailedEvent); ok {
+				failureEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for TemplateRenderFailedEvent")
+		}
+	}
+
+Done:
+	require.NotNil(t, failureEvent)
+	assert.Equal(t, "broken.map", failureEvent.TemplateName)
+	assert.NotEmpty(t, failureEvent.Error)
+}
+
+// TestRenderer_EmptyStores tests rendering with empty resource stores.
+func TestRenderer_EmptyStores(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: `global
+    daemon
+
+{% if resources.ingresses|length == 0 %}
+# No ingresses configured
+{% endif %}
+`,
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": &mockStore{items: []interface{}{}}, // Empty store
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go renderer.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	bus.Publish(events.NewReconciliationTriggeredEvent("test"))
+
+	timeout := time.After(1 * time.Second)
+	var renderedEvent *events.TemplateRenderedEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.TemplateRenderedEvent); ok {
+				renderedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for TemplateRenderedEvent")
+		}
+	}
+
+Done:
+	require.NotNil(t, renderedEvent)
+	assert.Contains(t, renderedEvent.HAProxyConfig, "# No ingresses configured")
+}
+
+// TestRenderer_MultipleStores tests rendering with multiple resource types.
+func TestRenderer_MultipleStores(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: `global
+    daemon
+
+# Ingresses: {{ resources.ingresses|length }}
+# Services: {{ resources.services|length }}
+# Pods: {{ resources.pods|length }}
+`,
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": &mockStore{
+			items: []interface{}{
+				map[string]interface{}{"kind": "Ingress"},
+				map[string]interface{}{"kind": "Ingress"},
+			},
+		},
+		"services": &mockStore{
+			items: []interface{}{
+				map[string]interface{}{"kind": "Service"},
+			},
+		},
+		"pods": &mockStore{
+			items: []interface{}{
+				map[string]interface{}{"kind": "Pod"},
+				map[string]interface{}{"kind": "Pod"},
+				map[string]interface{}{"kind": "Pod"},
+			},
+		},
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go renderer.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	bus.Publish(events.NewReconciliationTriggeredEvent("test"))
+
+	timeout := time.After(1 * time.Second)
+	var renderedEvent *events.TemplateRenderedEvent
+
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.TemplateRenderedEvent); ok {
+				renderedEvent = e
+				goto Done
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for TemplateRenderedEvent")
+		}
+	}
+
+Done:
+	require.NotNil(t, renderedEvent)
+	assert.Contains(t, renderedEvent.HAProxyConfig, "# Ingresses: 2")
+	assert.Contains(t, renderedEvent.HAProxyConfig, "# Services: 1")
+	assert.Contains(t, renderedEvent.HAProxyConfig, "# Pods: 3")
+}
+
+// TestRenderer_ContextCancellation tests graceful shutdown on context cancellation.
+func TestRenderer_ContextCancellation(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: "global\n    daemon\n",
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": &mockStore{},
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start renderer
+	done := make(chan error, 1)
+	go func() {
+		done <- renderer.Start(ctx)
+	}()
+
+	// Cancel context
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Should return quickly
+	timeout := time.After(1 * time.Second)
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "Start should return nil on context cancellation")
+	case <-timeout:
+		t.Fatal("Renderer did not shut down within timeout")
+	}
+}
+
+// TestRenderer_MultipleReconciliations tests handling multiple reconciliation triggers.
+func TestRenderer_MultipleReconciliations(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: "global\n    daemon\n# Count: {{ resources.ingresses|length }}\n",
+		},
+	}
+
+	ingressStore := &mockStore{
+		items: []interface{}{
+			map[string]interface{}{"name": "ing1"},
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": ingressStore,
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	eventChan := bus.Subscribe(50)
+	bus.Start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go renderer.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	// Trigger first reconciliation
+	bus.Publish(events.NewReconciliationTriggeredEvent("first"))
+
+	// Wait for first render
+	timeout1 := time.After(500 * time.Millisecond)
+	receivedFirst := false
+
+Loop1:
+	for {
+		select {
+		case event := <-eventChan:
+			if _, ok := event.(*events.TemplateRenderedEvent); ok {
+				receivedFirst = true
+				break Loop1
+			}
+		case <-timeout1:
+			t.Fatal("Timeout waiting for first render")
+		}
+	}
+
+	assert.True(t, receivedFirst)
+
+	// Add more ingresses to store
+	ingressStore.items = append(ingressStore.items, map[string]interface{}{"name": "ing2"})
+
+	// Trigger second reconciliation
+	bus.Publish(events.NewReconciliationTriggeredEvent("second"))
+
+	// Wait for second render
+	timeout2 := time.After(500 * time.Millisecond)
+	var secondEvent *events.TemplateRenderedEvent
+
+Loop2:
+	for {
+		select {
+		case event := <-eventChan:
+			if e, ok := event.(*events.TemplateRenderedEvent); ok {
+				secondEvent = e
+				break Loop2
+			}
+		case <-timeout2:
+			t.Fatal("Timeout waiting for second render")
+		}
+	}
+
+	require.NotNil(t, secondEvent)
+	assert.Contains(t, secondEvent.HAProxyConfig, "# Count: 2")
+}
+
+// TestBuildRenderingContext tests the context building logic.
+func TestBuildRenderingContext(t *testing.T) {
+	bus := busevents.NewEventBus(100)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := &config.Config{
+		HAProxyConfig: config.HAProxyConfig{
+			Template: "global\n    daemon\n",
+		},
+	}
+
+	stores := map[string]types.Store{
+		"ingresses": &mockStore{
+			items: []interface{}{
+				map[string]interface{}{"name": "ing1"},
+				map[string]interface{}{"name": "ing2"},
+			},
+		},
+		"services": &mockStore{
+			items: []interface{}{
+				map[string]interface{}{"name": "svc1"},
+			},
+		},
+	}
+
+	renderer, err := New(bus, cfg, stores, logger)
+	require.NoError(t, err)
+
+	// Build context
+	ctx := renderer.buildRenderingContext()
+
+	// Verify structure
+	require.Contains(t, ctx, "resources")
+
+	resources, ok := ctx["resources"].(map[string]interface{})
+	require.True(t, ok, "resources should be a map")
+
+	// Verify ingresses
+	ingresses, ok := resources["ingresses"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, ingresses, 2)
+
+	// Verify services
+	services, ok := resources["services"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, services, 1)
+}

--- a/pkg/controller/renderer/context.go
+++ b/pkg/controller/renderer/context.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Philipp Hossner
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+// buildRenderingContext extracts all resources from stores and builds the template context.
+//
+// The context structure is:
+//
+//	{
+//	  "resources": {
+//	    "ingresses": [...],  // All resources of type "ingresses"
+//	    "services": [...],   // All resources of type "services"
+//	    "secrets": [...],    // All resources of type "secrets"
+//	    // ... other watched resources
+//	  }
+//	}
+//
+// Templates can access resources like: {{ resources.ingresses }}.
+func (c *Component) buildRenderingContext() map[string]interface{} {
+	// Create resources map
+	resources := make(map[string]interface{})
+
+	// Extract all resources from each store
+	for resourceTypeName, store := range c.stores {
+		resourceList, err := store.List()
+		if err != nil {
+			c.logger.Warn("failed to list resources from store",
+				"resource_type", resourceTypeName,
+				"error", err)
+			// Continue with empty list for this resource type
+			resources[resourceTypeName] = []interface{}{}
+			continue
+		}
+
+		resources[resourceTypeName] = resourceList
+	}
+
+	// Build final context with resources under "resources" key
+	context := map[string]interface{}{
+		"resources": resources,
+	}
+
+	return context
+}

--- a/pkg/core/config/types.go
+++ b/pkg/core/config/types.go
@@ -62,6 +62,11 @@ type Config struct {
 	// These generate auxiliary files like custom error pages.
 	Files map[string]GeneralFile `yaml:"files"`
 
+	// SSLCertificates maps certificate names to their template definitions.
+	//
+	// These generate SSL certificate files for HAProxy.
+	SSLCertificates map[string]SSLCertificate `yaml:"ssl_certificates"`
+
 	// HAProxyConfig contains the main HAProxy configuration template.
 	HAProxyConfig HAProxyConfig `yaml:"haproxy_config"`
 }
@@ -145,6 +150,12 @@ type MapFile struct {
 // GeneralFile is a general-purpose auxiliary file template.
 type GeneralFile struct {
 	// Template is the template content that generates the file.
+	Template string `yaml:"template"`
+}
+
+// SSLCertificate is an SSL certificate file template.
+type SSLCertificate struct {
+	// Template is the template content that generates the certificate file.
 	Template string `yaml:"template"`
 }
 


### PR DESCRIPTION
This PR implements the Renderer component as a Stage 5 component that renders HAProxy configuration and auxiliary files from templates using Kubernetes resource state.

## Changes

**Component Architecture:**
- Event-driven component subscribing to ReconciliationTriggeredEvent
- Pre-compiles all templates at startup for optimal performance
- Builds rendering context from all resource stores
- Publishes TemplateRenderedEvent or TemplateRenderFailedEvent

**Added Renderer Component** (pkg/controller/renderer/):
- component.go: Main component with event subscription and orchestration
- context.go: Builds rendering context with resources under "resources" key
- component_test.go: 10 comprehensive test cases (all passing)

**Enhanced Event Types** (pkg/controller/events/types.go):
- Updated TemplateRenderedEvent to carry rendered config and auxiliary files
- Added fields: HAProxyConfig, AuxiliaryFiles, ConfigBytes, AuxiliaryFileCount
- Updated TemplateRenderFailedEvent with TemplateName for better errors

**Extended Configuration** (pkg/core/config/types.go):
- Added SSLCertificate type for SSL certificate templates
- All three auxiliary file types (maps, files, certs) now template-driven

**Updated Executor** (pkg/controller/executor/executor.go):
- Added handlers for TemplateRenderedEvent and TemplateRenderFailedEvent
- Publishes ReconciliationFailedEvent on rendering failures
- Prepared for future validation and deployment phases

**Enhanced Commentator** (pkg/controller/commentator/commentator.go):
- Added domain-aware logging for template rendering events
- Shows config size, auxiliary file count, and rendering duration

**Integrated into Controller** (pkg/controller/controller.go):
- Modified setupResourceWatchers to return ResourceWatcherComponent
- Updated setupReconciliation to create and start Renderer
- Renderer receives stores via GetAllStores() from ResourceWatcher
- Stage 5 now runs: Reconciler → Renderer → Executor

## Template Context Structure

Templates receive all indexed resources under the "resources" key:
```json
{
  "resources": {
    "ingresses": [...],
    "services": [...],
    "pods": [...]
  }
}
```

Templates access resources via: `{{ resources.ingresses }}`

## Testing

- 10 comprehensive test cases covering all code paths
- Tests include: success paths, error handling, multiple stores, cancellation
- All controller package tests pass
- Project builds successfully with no regressions

## Test Plan

Run the controller tests:
```bash
go test ./pkg/controller/renderer/... -v
go test ./pkg/controller/... -v
```