### PR TITLE
Support auxiliary file updates without configuration changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,17 +300,32 @@ kubectl config use-context kind-haproxy-template-ic-dev
 ./scripts/start-dev-env.sh
 
 # Build and deploy changes to dev cluster
-make build
-docker build -t haproxy-template-ic:dev .
-kind load docker-image haproxy-template-ic:dev --name haproxy-template-ic-dev
-kubectl rollout restart deployment haproxy-template-ic -n haproxy-template-ic
+./scripts/start-dev-env.sh restart
+
+# Or if you need to manually run the build steps:
+# make build
+# docker build -t haproxy-template-ic:dev .
+# kind load docker-image haproxy-template-ic:dev --name haproxy-template-ic-dev
+# kubectl rollout restart deployment haproxy-template-ic -n haproxy-template-ic
 
 # View controller logs
-kubectl logs -f -l app.kubernetes.io/name=haproxy-template-ic -n haproxy-template-ic
+./scripts/start-dev-env.sh logs
+
+# Or use kubectl directly:
+# kubectl logs -f -l app.kubernetes.io/name=haproxy-template-ic -n haproxy-template-ic
+
+# Check deployment status
+./scripts/start-dev-env.sh status
+
+# Test ingress functionality
+./scripts/start-dev-env.sh test
 
 # Check HAProxy configuration
 kubectl -n echo get pods -l app=haproxy
 kubectl -n echo exec <haproxy-pod> -- cat /etc/haproxy/haproxy.cfg
+
+# Clean up dev environment
+./scripts/start-dev-env.sh down
 ```
 
 **Cluster Names:**

--- a/charts/haproxy-template-ic/values.yaml
+++ b/charts/haproxy-template-ic/values.yaml
@@ -82,8 +82,8 @@ controller:
     template_snippets:
       backend-name:
         name: backend-name
-        template: |
-          ing_{{ ingress.metadata.namespace }}_{{ ingress.metadata.name }}_{{ path.backend.service.name }}_{{ path.backend.service.port.name | default(path.backend.service.port.number) }}
+        template: >-
+          {{- " " -}}ing_{{ ingress.metadata.namespace }}_{{ ingress.metadata.name }}_{{ path.backend.service.name }}_{{ path.backend.service.port.name | default(path.backend.service.port.number) }}
 
       backend-servers:
         name: backend-servers
@@ -127,10 +127,10 @@ controller:
           {%- for ingress in resources.ingresses.List() %}
           {%- for rule in (ingress.spec.rules | default([]) | selectattr("http", "defined")) %}
           {%- for path in (rule.http.paths | default([]) | selectattr("path", "defined") | selectattr("pathType", "in", path_types)) %}
-          {{ rule.host }}{{ path.path }} {% include "backend-name" %}{{ suffix }}
-          {%- endfor %}
-          {%- endfor %}
-          {%- endfor %}
+          {{ rule.host }}{{ path.path }} {% include "backend-name" -%}{{ suffix }}
+          {% endfor %}
+          {% endfor %}
+          {% endfor %}
 
       ingress-backends:
         name: ingress-backends
@@ -185,25 +185,28 @@ controller:
           # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
           # It should be used with the equality string matcher. Example:
           #   http-request set-var(txn.path_match) var(txn.host_match),concat(,txn.path,),map(/etc/haproxy/maps/path-exact.map)
-          {%- set path_types = ["Exact"] %}
+          {% set path_types = ["Exact"] %}
           {%- set suffix = "" %}
           {% include "path-map-entry" %}
+
 
       path-prefix-exact.map:
         template: |
           # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
-          {%- set path_types = ["Prefix", "ImplementationSpecific"] %}
+          {% set path_types = ["Prefix", "ImplementationSpecific"] %}
           {%- set suffix = "" %}
           {% include "path-map-entry" %}
+
 
       path-prefix.map:
         template: |
           # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
           # It should be used with the prefix string matcher. Example:
           #   http-request set-var(txn.path_match) var(txn.host_match),concat(,txn.path,),map_beg(maps/path-prefix.map)
-          {%- set path_types = ["Prefix", "ImplementationSpecific"] %}
+          {% set path_types = ["Prefix", "ImplementationSpecific"] %}
           {%- set suffix = "/" %}
           {% include "path-map-entry" %}
+
 
     files:
       400.http:

--- a/pkg/dataplane/auxiliaryfiles/types.go
+++ b/pkg/dataplane/auxiliaryfiles/types.go
@@ -101,6 +101,11 @@ type FileDiff struct {
 	ToDelete []string
 }
 
+// HasChanges returns true if there are any changes to general files.
+func (d *FileDiff) HasChanges() bool {
+	return len(d.ToCreate) > 0 || len(d.ToUpdate) > 0 || len(d.ToDelete) > 0
+}
+
 // SSLCertificateDiff represents the differences between current and desired SSL certificate states.
 // It contains lists of certificates that need to be created, updated, or deleted.
 type SSLCertificateDiff struct {
@@ -115,6 +120,11 @@ type SSLCertificateDiff struct {
 	ToDelete []string
 }
 
+// HasChanges returns true if there are any changes to SSL certificates.
+func (d *SSLCertificateDiff) HasChanges() bool {
+	return len(d.ToCreate) > 0 || len(d.ToUpdate) > 0 || len(d.ToDelete) > 0
+}
+
 // MapFileDiff represents the differences between current and desired map file states.
 // It contains lists of map files that need to be created, updated, or deleted.
 type MapFileDiff struct {
@@ -127,4 +137,9 @@ type MapFileDiff struct {
 	// ToDelete contains map file paths that exist in the current state but not in the desired state.
 	// These are file paths (not full MapFile structs) since we only need the path to delete.
 	ToDelete []string
+}
+
+// HasChanges returns true if there are any changes to map files.
+func (d *MapFileDiff) HasChanges() bool {
+	return len(d.ToCreate) > 0 || len(d.ToUpdate) > 0 || len(d.ToDelete) > 0
 }

--- a/pkg/dataplane/client/storage_maps.go
+++ b/pkg/dataplane/client/storage_maps.go
@@ -136,7 +136,8 @@ func (c *DataplaneClient) UpdateMapFile(ctx context.Context, name, content strin
 		return fmt.Errorf("map file '%s' not found", name)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	// Accept both 200 (OK) and 202 (Accepted) as success
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		// Try to read error body for more details
 		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("update map file '%s' failed with status %d: %s", name, resp.StatusCode, string(bodyBytes))

--- a/pkg/templating/CLAUDE.md
+++ b/pkg/templating/CLAUDE.md
@@ -493,6 +493,15 @@ This package uses Gonja v2 (`github.com/nikolalohinski/gonja/v2`):
 
 ### Gonja Quirks
 
+**CRITICAL: Escape sequences in string literals not supported:**
+```jinja2
+{{ "\n" }}  {# Does NOT produce a newline! #}
+{{ "Line 1\nLine 2" }}  {# Output: Line 1\nLine 2 (literal backslash-n) #}
+```
+Gonja does not interpret escape sequences (`\n`, `\t`, etc.) in string literals. The backslash-n is output as literal characters or ignored entirely. This is a fundamental limitation of Gonja.
+
+**Workaround**: Use actual newlines in templates or pass newlines through context variables.
+
 **Whitespace handling:**
 ```jinja2
 {% if true %}

--- a/tests/integration/sync_auxiliary_test.go
+++ b/tests/integration/sync_auxiliary_test.go
@@ -193,6 +193,30 @@ func TestSyncAuxiliary(t *testing.T) {
 			},
 			expectedReload: true,
 		},
+		{
+			name:              "update-map-only-no-config-change",
+			initialConfigFile: "map-frontend/with-map.cfg",
+			desiredConfigFile: "map-frontend/with-map.cfg", // SAME config - no changes
+			// Initial config needs this map
+			initialMapFiles: map[string]string{
+				"domains.map": "map-files/domains.map",
+			},
+			// Desired config needs different map content
+			mapFiles: map[string]string{
+				"domains.map": "map-files/domains-updated.map", // Same name, different content
+			},
+			expectedCreates: 0,
+			expectedUpdates: 0,
+			expectedDeletes: 0,
+			expectedOperations: []string{
+				// No HAProxy config operations expected - config is identical
+			},
+			expectedReload: false, // No config changes, but map should still update
+			// Verify the map file was actually updated
+			verifyMapFiles: map[string]string{
+				"domains.map": "map-files/domains-updated.map",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/tests/integration/testdata/map-files/domains-updated.map
+++ b/tests/integration/testdata/map-files/domains-updated.map
@@ -1,0 +1,4 @@
+example.com web
+api.example.com api
+blog.example.com web
+shop.example.com web


### PR DESCRIPTION
This change enables the orchestrator to detect and apply updates to auxiliary files (map files, SSL certificates, general files) even when the HAProxy configuration itself remains unchanged.

Previously, if only auxiliary file content changed without any HAProxy config modifications (e.g., updating a map file entry while keeping the HAProxy config identical), the orchestrator would report "no changes" and skip the sync entirely. This behavior prevented important auxiliary file updates like map file modifications or certificate rotations from being applied when they didn't coincide with HAProxy config changes.

## Problem

Before this change, the orchestrator checked for configuration changes first and returned early if no changes were detected. This meant that auxiliary file changes were only detected and synced when they occurred alongside configuration changes.

## Solution

The orchestrator now compares auxiliary files before checking for configuration changes. If either configuration changes OR auxiliary file changes are detected, the sync proceeds. The auxiliary file comparison is performed in parallel for all file types (general files, SSL certificates, map files) for optimal performance.

## Key Changes

**Type System Improvements:**
- Added `HasChanges()` methods to `FileDiff`, `SSLCertificateDiff`, and `MapFileDiff` types for cleaner change detection

**Orchestrator Refactoring:**
- Moved auxiliary file comparison to occur before the "no changes" check in the sync workflow
- Split fine-grained sync logic into `attemptFineGrainedSyncWithDiffs` that accepts pre-computed diffs to avoid redundant comparison operations
- Extracted helper methods (`parseAndCompareConfigs`, `compareAuxiliaryFiles`, `executeConfigOperations`) to reduce cyclomatic complexity and improve maintainability

**Client Improvements:**
- Fixed map file update to accept HTTP 202 (Accepted) status code in addition to 200 (OK)

**Testing:**
- Added integration test case `update-map-only-no-config-change` that verifies map file updates work correctly when HAProxy config is identical

**Documentation:**
- Updated documentation to explain the new sync behavior and improved dev environment commands
- Fixed template examples in Helm values and design documentation

## Impact

This change ensures that:
- Map file updates are applied immediately, even when HAProxy config is stable
- SSL certificate rotations happen independently of config changes
- General file modifications are synced without requiring config updates
- The sync workflow correctly reports changes when only auxiliary files are modified