### PR TITLE
Separate ingress logic into dedicated template library

### DIFF
--- a/charts/haproxy-template-ic/libraries/base.yaml
+++ b/charts/haproxy-template-ic/libraries/base.yaml
@@ -1,11 +1,8 @@
 # Base template library for HAProxy Template Ingress Controller
-# Contains core template snippets, maps, files, and HAProxy configuration
+# Contains resource-agnostic core template snippets, files, and HAProxy configuration
+# Uses plugin patterns (resource_*) to discover resource-specific implementations
 
 templateSnippets:
-  backend-name:
-    template: >-
-      {{- " " -}}ing_{{ ingress.metadata.namespace }}_{{ ingress.metadata.name }}_{{ path.backend.service.name }}_{{ path.backend.service.port.name | default(path.backend.service.port.number) }}
-
   backend-servers:
     template: |
       {#- Pre-allocated server pool with auto-expansion #}
@@ -39,46 +36,6 @@ templateSnippets:
         {%- endif %}
       {%- endfor %}
 
-  path-map-entry:
-    template: |
-      {#- Generate map entries for paths matching specified pathTypes #}
-      {#- Usage: {% include "path-map-entry" with context %} where path_types = ["Exact"] or ["Prefix", "ImplementationSpecific"] #}
-      {%- for ingress in resources.ingresses.List() %}
-      {%- for rule in (ingress.spec.rules | default([]) | selectattr("http", "defined")) %}
-      {%- for path in (rule.http.paths | default([]) | selectattr("path", "defined") | selectattr("pathType", "in", path_types)) %}
-      {{ rule.host }}{{ path.path }} {% include "backend-name" -%}{{ suffix }}
-      {% endfor %}
-      {% endfor %}
-      {% endfor %}
-
-  ingress-backends:
-    template: |
-      {#- Generate all backend definitions from ingress resources #}
-      {#- Usage: {% include "ingress-backends" %} #}
-      {%- for ingress in resources.ingresses.List() %}
-      {%- if ingress.spec and ingress.spec.rules %}
-      {%- for rule in ingress.spec.rules %}
-      {%- if rule.http and rule.http.paths %}
-      {%- for path in rule.http.paths %}
-      {%- if path.backend and path.backend.service %}
-      {%- set service_name = path.backend.service.name %}
-      {%- set port = path.backend.service.port.number | default(80) %}
-
-      backend {%+ include "backend-name" +%}
-        balance roundrobin
-        option httpchk GET {{ path.path | default('/') }}
-        default-server check
-        {%- filter indent(2, first=True) %}
-        {% include "backend-annotations" %}
-        {% include "backend-servers" %}
-        {%- endfilter %}
-      {%- endif %}
-      {%- endfor %}
-      {%- endif %}
-      {%- endfor %}
-      {%- endif %}
-      {%- endfor %}
-
   top-level-annotations:
     priority: 100
     template: |
@@ -104,40 +61,43 @@ templateSnippets:
 maps:
   host.map:
     template: |
-      {%- for ingress in resources.ingresses.List() %}
-      {%- for rule in (ingress.spec.rules | default([]) | selectattr("http", "defined")) %}
-      {%- set host_without_asterisk = rule.host | replace('*', '', 1) %}
-      {{ host_without_asterisk }} {{ host_without_asterisk }}
-      {% endfor %}
-      {% endfor %}
+      {#- Generic host mapping infrastructure #}
+      {#- Resource libraries populate this map via map-entry-host-* snippets #}
+      {%- set matching = template_snippets | glob_match("map-entry-host-*") %}
+      {%- for snippet_name in matching %}
+      {%- include snippet_name -%}
+      {%- endfor %}
 
   path-exact.map:
     template: |
       # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
       # It should be used with the equality string matcher. Example:
       #   http-request set-var(txn.path_match) var(txn.host_match),concat(,txn.path,),map({{ "path-exact.map" | get_path("map") }})
-      {% set path_types = ["Exact"] %}
-      {%- set suffix = "" %}
-      {% include "path-map-entry" %}
-
+      {#- Resource libraries populate this map via map-entry-path-exact-* snippets #}
+      {%- set matching = template_snippets | glob_match("map-entry-path-exact-*") %}
+      {%- for snippet_name in matching %}
+      {%- include snippet_name -%}
+      {%- endfor %}
 
   path-prefix-exact.map:
     template: |
       # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
-      {% set path_types = ["Prefix", "ImplementationSpecific"] %}
-      {%- set suffix = "" %}
-      {% include "path-map-entry" %}
-
+      {#- Resource libraries populate this map via map-entry-path-prefix-exact-* snippets #}
+      {%- set matching = template_snippets | glob_match("map-entry-path-prefix-exact-*") %}
+      {%- for snippet_name in matching %}
+      {%- include snippet_name -%}
+      {%- endfor %}
 
   path-prefix.map:
     template: |
       # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
       # It should be used with the prefix string matcher. Example:
       #   http-request set-var(txn.path_match) var(txn.host_match),concat(,txn.path,),map_beg({{ "path-prefix.map" | get_path("map") }})
-      {% set path_types = ["Prefix", "ImplementationSpecific"] %}
-      {%- set suffix = "/" %}
-      {% include "path-map-entry" %}
-
+      {#- Resource libraries populate this map via map-entry-path-prefix-* snippets #}
+      {%- set matching = template_snippets | glob_match("map-entry-path-prefix-*") %}
+      {%- for snippet_name in matching %}
+      {%- include snippet_name -%}
+      {%- endfor %}
 
 files:
   400.http:
@@ -275,7 +235,12 @@ haproxyConfig:
         # Default backend
         default_backend default_backend
 
-    {% include "ingress-backends" %}
+    {#- Include all resource-specific backend definitions using plugin pattern #}
+    {#- Resource libraries implement resource_*_backends snippets (e.g., resource_ingress_backends, resource_gateway_backends) #}
+    {%- set matching = template_snippets | glob_match("resource_*_backends") %}
+    {%- for snippet_name in matching %}
+    {% include snippet_name %}
+    {%- endfor %}
 
     backend default_backend
         http-request return status 404

--- a/charts/haproxy-template-ic/libraries/gateway.yaml
+++ b/charts/haproxy-template-ic/libraries/gateway.yaml
@@ -1,0 +1,26 @@
+# Gateway API template library for HAProxy Template Ingress Controller
+# Provides support for Kubernetes Gateway API (gateway.networking.k8s.io)
+# Implements the resource_gateway_* plugin interface for the base library
+#
+# This library is currently a placeholder for future Gateway API support.
+# When implemented, it will provide routing for:
+# - HTTPRoute resources
+# - TCPRoute resources
+# - TLSRoute resources
+# - GRPCRoute resources
+#
+# Expected plugin interface:
+# - resource_gateway_backends: Generate backend definitions from Gateway API routes
+# - resource_gateway_backend-name: Generate backend names for Gateway API routes
+# - Maps for Gateway API routing (similar to path-exact.map, path-prefix.map for Ingress)
+
+templateSnippets:
+  # Future: resource_gateway_backends
+  # Future: resource_gateway_backend-name
+  # Future: resource_gateway_route-map-entry
+
+maps:
+  # Future: Gateway API route matching maps
+
+files:
+  # Future: Gateway API-specific files if needed

--- a/charts/haproxy-template-ic/libraries/ingress.yaml
+++ b/charts/haproxy-template-ic/libraries/ingress.yaml
@@ -1,0 +1,79 @@
+# Ingress template library for HAProxy Template Ingress Controller
+# Provides support for Kubernetes networking.k8s.io/v1 Ingress resources
+# Implements the resource_ingress_* plugin interface for the base library
+
+templateSnippets:
+  resource_ingress_backend-name:
+    template: >-
+      {{- " " -}}ing_{{ ingress.metadata.namespace }}_{{ ingress.metadata.name }}_{{ path.backend.service.name }}_{{ path.backend.service.port.name | default(path.backend.service.port.number) }}
+
+  resource_ingress_path-map-entry:
+    template: |
+      {#- Generate map entries for paths matching specified pathTypes #}
+      {#- Usage: {% include "resource_ingress_path-map-entry" with context %} where path_types = ["Exact"] or ["Prefix", "ImplementationSpecific"] #}
+      {%- for ingress in resources.ingresses.List() %}
+      {%- for rule in (ingress.spec.rules | default([]) | selectattr("http", "defined")) %}
+      {%- for path in (rule.http.paths | default([]) | selectattr("path", "defined") | selectattr("pathType", "in", path_types)) %}
+      {{ rule.host }}{{ path.path }} {% include "resource_ingress_backend-name" -%}{{ suffix }}
+      {% endfor %}
+      {% endfor %}
+      {% endfor %}
+
+  resource_ingress_backends:
+    template: |
+      {#- Generate all backend definitions from ingress resources #}
+      {#- Usage: {% include "resource_ingress_backends" %} #}
+      {%- for ingress in resources.ingresses.List() %}
+      {%- if ingress.spec and ingress.spec.rules %}
+      {%- for rule in ingress.spec.rules %}
+      {%- if rule.http and rule.http.paths %}
+      {%- for path in rule.http.paths %}
+      {%- if path.backend and path.backend.service %}
+      {%- set service_name = path.backend.service.name %}
+      {%- set port = path.backend.service.port.number | default(80) %}
+
+      backend {%+ include "resource_ingress_backend-name" +%}
+        balance roundrobin
+        option httpchk GET {{ path.path | default('/') }}
+        default-server check
+        {%- filter indent(2, first=True) %}
+        {% include "backend-annotations" %}
+        {% include "backend-servers" %}
+        {%- endfilter %}
+      {%- endif %}
+      {%- endfor %}
+      {%- endif %}
+      {%- endfor %}
+      {%- endif %}
+      {%- endfor %}
+
+  map-entry-host-ingress:
+    template: |
+      {#- Generate host map entries for Ingress resources #}
+      {%- for ingress in resources.ingresses.List() %}
+      {%- for rule in (ingress.spec.rules | default([]) | selectattr("http", "defined")) %}
+      {%- set host_without_asterisk = rule.host | replace('*', '', 1) %}
+      {{ host_without_asterisk }} {{ host_without_asterisk }}
+      {% endfor %}
+      {% endfor %}
+
+  map-entry-path-exact-ingress:
+    template: |
+      {#- Generate exact path map entries for Ingress resources #}
+      {% set path_types = ["Exact"] %}
+      {%- set suffix = "" %}
+      {% include "resource_ingress_path-map-entry" %}
+
+  map-entry-path-prefix-exact-ingress:
+    template: |
+      {#- Generate prefix-exact path map entries for Ingress resources #}
+      {% set path_types = ["Prefix", "ImplementationSpecific"] %}
+      {%- set suffix = "" %}
+      {% include "resource_ingress_path-map-entry" %}
+
+  map-entry-path-prefix-ingress:
+    template: |
+      {#- Generate prefix path map entries with trailing slash for Ingress resources #}
+      {% set path_types = ["Prefix", "ImplementationSpecific"] %}
+      {%- set suffix = "/" %}
+      {% include "resource_ingress_path-map-entry" %}

--- a/charts/haproxy-template-ic/templates/_helpers.tpl
+++ b/charts/haproxy-template-ic/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Create the name of the service account to use
 
 {{/*
 Merge template libraries based on enabled flags
-Returns merged config with libraries applied in order: base -> haproxytech -> values.yaml
+Returns merged config with libraries applied in order: base -> ingress -> gateway -> haproxytech -> values.yaml
 */}}
 {{- define "haproxy-template-ic.mergeLibraries" -}}
 {{- $merged := dict }}
@@ -73,6 +73,18 @@ Returns merged config with libraries applied in order: base -> haproxytech -> va
 {{- if $context.Values.controller.templateLibraries.base.enabled }}
   {{- $baseLibrary := $context.Files.Get "libraries/base.yaml" | fromYaml }}
   {{- $merged = merge $merged $baseLibrary }}
+{{- end }}
+
+{{- /* Load ingress library if enabled */ -}}
+{{- if $context.Values.controller.templateLibraries.ingress.enabled }}
+  {{- $ingressLibrary := $context.Files.Get "libraries/ingress.yaml" | fromYaml }}
+  {{- $merged = merge $merged $ingressLibrary }}
+{{- end }}
+
+{{- /* Load gateway library if enabled */ -}}
+{{- if $context.Values.controller.templateLibraries.gateway.enabled }}
+  {{- $gatewayLibrary := $context.Files.Get "libraries/gateway.yaml" | fromYaml }}
+  {{- $merged = merge $merged $gatewayLibrary }}
 {{- end }}
 
 {{- /* Load haproxytech library if enabled */ -}}

--- a/charts/haproxy-template-ic/values.yaml
+++ b/charts/haproxy-template-ic/values.yaml
@@ -29,15 +29,27 @@ controller:
 
   # Template libraries
   # Control which predefined template libraries to include
-  # Libraries are merged in order: base -> haproxytech -> values.yaml
+  # Libraries are merged in order: base -> ingress -> gateway -> haproxytech -> values.yaml
   # User-provided config in controller.config always takes precedence
   templateLibraries:
-    # Base library: Core template snippets, maps, files, and HAProxy configuration
-    # Provides fundamental ingress routing and backend management
+    # Base library: Resource-agnostic core configuration
+    # Provides generic HAProxy configuration, error pages, and plugin orchestration
+    # Uses resource_* patterns to discover and include resource-specific implementations
     base:
       enabled: true
+    # Ingress library: Kubernetes Ingress resource support
+    # Provides routing and backend management for networking.k8s.io/v1 Ingress resources
+    # Implements resource_ingress_* plugin interface (backends, maps, routing logic)
+    ingress:
+      enabled: true
+    # Gateway library: Kubernetes Gateway API support (placeholder for future implementation)
+    # Will provide routing for gateway.networking.k8s.io resources (HTTPRoute, TCPRoute, etc.)
+    # Will implement resource_gateway_* plugin interface
+    gateway:
+      enabled: false
     # HAProxyTech library: Support for haproxy.org/* annotations
     # Currently includes basic authentication (haproxy.org/auth-type, haproxy.org/auth-secret)
+    # Works with both Ingress and Gateway API resources
     haproxytech:
       enabled: true
 


### PR DESCRIPTION
This PR extracts ingress-specific templates from the base library into a new ingress library, making the base library truly resource-agnostic and standalone. The architecture now uses a plugin pattern where resource libraries (ingress, gateway) plug into generic infrastructure provided by base.

## Changes

**New template libraries:**
- `ingress.yaml`: Kubernetes Ingress resource support with `resource_ingress_*` templates and `map-entry-*-ingress` snippets
- `gateway.yaml`: Scaffold for future Gateway API support

**Refactored base library:**
- Moved map definitions (host.map, path-*.map) from ingress to base
- Maps use orchestrator pattern with `glob_match("map-entry-*")` to collect entries
- Backend orchestrator uses `glob_match("resource_*_backends")` pattern
- Base is now standalone - generates valid config without resource libraries

**Configuration updates:**
- Library loading order: base → ingress → gateway → haproxytech → user config
- Added `ingress.enabled` (default: true) and `gateway.enabled` (default: false) settings
- Updated documentation explaining the plugin architecture

## Architecture

**Base library provides:**
- Universal HAProxy infrastructure (global, defaults, frontends, error pages)
- Generic map infrastructure that resource libraries populate
- Orchestrator patterns for discovering and including resource implementations

**Resource libraries provide:**
- `map-entry-*` snippets to populate base maps with resource-specific entries
- `resource_*_backends` snippets to generate backend definitions
- Resource-specific routing and backend management logic

**Key insight:** Maps are universal infrastructure (belong in base), but their content is resource-specific (provided by ingress/gateway libraries).

## Benefits

- Base library works standalone with empty maps (all requests return 404)
- Users can disable ingress support: `controller.templateLibraries.ingress.enabled: false`
- Clean plugin interface for Gateway API implementation
- Multiple resource libraries can coexist (ingress + gateway simultaneously)
- No breaking changes - ingress enabled by default

## Testing

- ✅ Base-only config generates valid HAProxy configuration
- ✅ Full config with ingress enabled works correctly  
- ✅ Maps populated correctly (host.map, path-*.map)
- ✅ Ingress backends generated correctly
- ✅ End-to-end tests pass (echo service accessible)
- ✅ No errors or warnings in controller logs
- ✅ Pre-commit hooks pass