### PR TITLE
Refactor template snippet naming and add route testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,37 @@ jobs:
 
           # Validate the merged configuration
           ./bin/controller validate -f /tmp/merged-config.yaml
+
+  test-routes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kind
+        run: |
+          # Install kind for creating local Kubernetes cluster
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Start dev environment
+        run: |
+          # Start dev environment (creates cluster, builds image, deploys controller)
+          ./scripts/start-dev-env.sh
+
+      - name: Run route tests
+        run: |
+          # Test all ingress and HTTPRoute resources
+          ./scripts/test-routes.sh
+
+      - name: Cleanup
+        if: always()
+        run: |
+          # Delete kind cluster
+          kind delete cluster --name haproxy-template-ic-dev || true

--- a/charts/haproxy-template-ic/libraries/base.yaml
+++ b/charts/haproxy-template-ic/libraries/base.yaml
@@ -3,10 +3,10 @@
 # Uses plugin patterns (resource_*) to discover resource-specific implementations
 
 templateSnippets:
-  macros:
+  util-macros:
     template: |
       {#- Reusable macro: Include all snippets matching a glob pattern #}
-      {#- Usage: {% from "macros" import include_matching %}{{ include_matching("pattern-*") }} #}
+      {#- Usage: {% from "util-macros" import include_matching %}{{ include_matching("pattern-*") }} #}
       {%- macro include_matching(pattern) -%}
       {%- set matching = template_snippets | glob_match(pattern) %}
       {%- for snippet_name in matching %}
@@ -14,23 +14,23 @@ templateSnippets:
       {%- endfor %}
       {%- endmacro -%}
 
-  regex-sanitize:
+  util-regex-sanitize:
     template: |
       {#- Macro to sanitize regex patterns for HAProxy double-quoted context #}
       {#- Escapes $ as \$ to prevent environment variable substitution #}
-      {#- Usage: {% from "regex-sanitize" import sanitize_regex %}{{ sanitize_regex(pattern) }} #}
+      {#- Usage: {% from "util-regex-sanitize" import sanitize_regex %}{{ sanitize_regex(pattern) }} #}
       {%- macro sanitize_regex(pattern) -%}
       {%- set result = pattern | replace("$", "\\$") -%}
       {{- result -}}
       {%- endmacro -%}
 
-  use-backend-selection:
+  frontend-routing-logic:
     template: |
-      {#- Backend selection logic with qualifier system #}
+      {#- Frontend routing logic with qualifier system #}
       {#- Supports BACKEND and MULTIBACKEND qualifiers #}
       {#- Default ordering: Exact > Regex > Prefix (de facto standard) #}
       {#- Override this snippet in path-regex-last library for performance-first ordering #}
-      # base/use-backend-selection
+      # base/frontend-routing-logic
 
       # Set variables for path-based routing
       http-request set-var(txn.base) base
@@ -51,9 +51,9 @@ templateSnippets:
 
       # Extension point for advanced matchers (method/header/query)
       # Libraries can inject ordered http-request statements here
-      {%- from "macros" import include_matching -%}
+      {%- from "util-macros" import include_matching -%}
       {%- filter indent(6, first=True) %}
-      {{ include_matching("advanced-matcher-*") }}
+      {{ include_matching("frontend-matchers-advanced-*") }}
       {%- endfilter %}
 
       # Re-parse path_match_qualifier after advanced matchers may have changed path_match
@@ -75,11 +75,7 @@ templateSnippets:
       # Result: sets txn.backend_name directly
       http-request set-var(txn.backend_name) var(txn.path_match),field(2,:) if { var(txn.path_match_qualifier) -m str BACKEND }
 
-      # Use backend from txn.backend_name (set by qualifier logic above)
-      # Falls through to default_backend if backend_name is empty
-      use_backend %[var(txn.backend_name)] if { var(txn.backend_name) -m found }
-
-  backend-servers:
+  util-backend-servers:
     template: |
       {#- Pre-allocated server pool with auto-expansion #}
       {%- set initial_slots = 10 %}  {#- Single place to adjust initial slots #}
@@ -100,7 +96,7 @@ templateSnippets:
       {%- set active_count = ns.active_endpoints|length %}
       {#- For now, just use initial_slots since we have few endpoints #}
       {%- set max_servers = initial_slots %}
-      # base/backend-servers
+      # base/util-backend-servers
 
       {#- Generate all server slots with fixed names #}
       {%- for i in range(1, max_servers + 1) %}
@@ -114,32 +110,32 @@ templateSnippets:
         {%- endif %}
       {%- endfor %}
 
-  top-level-annotations:
+  global-top:
     priority: 100
     template: |
-      {#- Orchestrator snippet that includes all top-level annotation snippets #}
-      {#- Top-level snippets generate HAProxy elements like userlist sections #}
-      {#- Usage: {% include "top-level-annotations" %} in haproxy.cfg #}
-      {%- from "macros" import include_matching -%}
-      {{- include_matching("top-level-annotation-*") -}}
+      {#- Orchestrator snippet that includes all global-top-* snippets #}
+      {#- Global snippets generate top-level HAProxy elements like userlist sections #}
+      {#- Usage: {% include "global-top" %} in haproxy.cfg #}
+      {%- from "util-macros" import include_matching -%}
+      {{- include_matching("global-top-*") -}}
 
-  backend-annotations:
+  backend-directives:
     priority: 100
     template: |
-      {#- Orchestrator snippet that includes all backend annotation snippets #}
-      {#- Backend snippets generate per-backend directives like http-request auth #}
-      {#- Usage: {% include "backend-annotations" %} in backend definitions #}
-      {%- from "macros" import include_matching -%}
-      {{- include_matching("backend-annotation-*") -}}
+      {#- Orchestrator snippet that includes all backend-directives-* snippets #}
+      {#- Backend directive snippets generate per-backend directives like http-request auth #}
+      {#- Usage: {% include "backend-directives" %} in backend definitions #}
+      {%- from "util-macros" import include_matching -%}
+      {{- include_matching("backend-directives-*") -}}
 
 maps:
   host.map:
     template: |
       # base/host.map
       {#- Generic host mapping infrastructure #}
-      {#- Resource libraries populate this map via map-entry-host-* snippets #}
-      {%- from "macros" import include_matching -%}
-      {{- include_matching("map-entry-host-*") -}}
+      {#- Resource libraries populate this map via map-host-* snippets #}
+      {%- from "util-macros" import include_matching -%}
+      {{- include_matching("map-host-*") -}}
 
   path-exact.map:
     template: |
@@ -147,17 +143,17 @@ maps:
       # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
       # It should be used with the equality string matcher. Example:
       #   http-request set-var(txn.path_match) var(txn.host_match),concat(,txn.path,),map({{ "path-exact.map" | get_path("map") }})
-      {#- Resource libraries populate this map via map-entry-path-exact-* snippets #}
-      {%- from "macros" import include_matching -%}
-      {{- include_matching("map-entry-path-exact-*") -}}
+      {#- Resource libraries populate this map via map-path-exact-* snippets #}
+      {%- from "util-macros" import include_matching -%}
+      {{- include_matching("map-path-exact-*") -}}
 
   path-prefix-exact.map:
     template: |
       # base/path-prefix-exact.map
       # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
-      {#- Resource libraries populate this map via map-entry-path-prefix-exact-* snippets #}
-      {%- from "macros" import include_matching -%}
-      {{- include_matching("map-entry-path-prefix-exact-*") -}}
+      {#- Resource libraries populate this map via map-path-prefix-exact-* snippets #}
+      {%- from "util-macros" import include_matching -%}
+      {{- include_matching("map-path-prefix-exact-*") -}}
 
   path-prefix.map:
     template: |
@@ -165,9 +161,9 @@ maps:
       # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
       # It should be used with the prefix string matcher. Example:
       #   http-request set-var(txn.path_match) var(txn.host_match),concat(,txn.path,),map_beg({{ "path-prefix.map" | get_path("map") }})
-      {#- Resource libraries populate this map via map-entry-path-prefix-beg-* snippets #}
-      {%- from "macros" import include_matching -%}
-      {{- include_matching("map-entry-path-prefix-beg-*") -}}
+      {#- Resource libraries populate this map via map-path-prefix-* snippets #}
+      {%- from "util-macros" import include_matching -%}
+      {{- include_matching("map-path-prefix-*") -}}
 
   path-regex.map:
     template: |
@@ -175,9 +171,9 @@ maps:
       # This map is used to match the host header (without ":port") concatenated with the requested path (without query params) to an HAProxy backend defined in haproxy.cfg.
       # It should be used with the regex string matcher. Example:
       #   http-request set-var(txn.path_match) var(txn.host_match),concat(,txn.path,),map_reg({{ "path-regex.map" | get_path("map") }})
-      {#- Resource libraries populate this map via map-entry-path-regex-* snippets #}
-      {%- from "macros" import include_matching -%}
-      {{- include_matching("map-entry-path-regex-*") -}}
+      {#- Resource libraries populate this map via map-path-regex-* snippets #}
+      {%- from "util-macros" import include_matching -%}
+      {{- include_matching("map-path-regex-*") -}}
 
   weighted-multi-backend.map:
     template: |
@@ -186,9 +182,9 @@ maps:
       # Maps random_number:route_key to backend name for MULTIBACKEND qualifier
       # Format: <0 to total_weight-1>:<namespace>_<resource>_<rule_idx> <backend_name>
       # Entries are expanded: weight N generates N consecutive entries
-      # Libraries populate via map-entries-weighted-multi-backend-* pattern
-      {% from "macros" import include_matching %}
-      {{- include_matching("map-entries-weighted-multi-backend-*") }}
+      # Libraries populate via map-weighted-backend-* pattern
+      {% from "util-macros" import include_matching %}
+      {{- include_matching("map-weighted-backend-*") }}
 
 files:
   400.http:
@@ -297,8 +293,8 @@ haproxyConfig:
         errorfile 503 {{ "503.http" | get_path("file") }}
         errorfile 504 {{ "504.http" | get_path("file") }}
 
-    {#- Include top-level annotation snippets (e.g., userlist sections) #}
-    {% include "top-level-annotations" %}
+    {#- Include global top-level snippets (e.g., userlist sections) #}
+    {% include "global-top" %}
 
     frontend status
         bind *:8404
@@ -309,9 +305,9 @@ haproxyConfig:
     frontend http_frontend
         bind *:80
 
-        {#- Include backend selection logic (can be overridden by libraries) #}
+        {#- Include frontend routing logic (can be overridden by libraries) #}
         {%- filter indent(8, first=False) %}
-        {% include "use-backend-selection" -%}
+        {% include "frontend-routing-logic" -%}
         {%- endfilter %}
 
         # Debug headers (when enabled via templating settings)
@@ -330,13 +326,25 @@ haproxyConfig:
         http-response set-header X-Gateway-Filters-Applied %[var(txn.filters_applied)] if { var(txn.filters_applied) -m found }
         {%- endif %}
 
+        {#- Extension point for frontend request/response filters #}
+        {#- Runs AFTER routing decisions, BEFORE backend selection #}
+        {#- Libraries can inject filter logic here (header modification, redirects, rewrites) #}
+        {%- from "util-macros" import include_matching -%}
+        {%- filter indent(8, first=True) %}
+        {{ include_matching("frontend-filters-*") }}
+        {%- endfilter %}
+
+        # Use backend from txn.backend_name (set by qualifier logic in "frontend-routing-logic")
+        # Falls through to default_backend if backend_name is empty
+        use_backend %[var(txn.backend_name)] if { var(txn.backend_name) -m found }
+
         # Default backend
         default_backend default_backend
 
     {#- Include all resource-specific backend definitions using plugin pattern #}
-    {#- Resource libraries implement resource_*_backends snippets (e.g., resource_ingress_backends, resource_gateway_backends) #}
-    {%- from "macros" import include_matching -%}
-    {{ include_matching("resource_*_backends") }}
+    {#- Resource libraries implement backends-* snippets (e.g., backends-ingress, backends-gateway) #}
+    {%- from "util-macros" import include_matching -%}
+    {{ include_matching("backends-*") }}
 
     backend default_backend
         http-request return status 404

--- a/charts/haproxy-template-ic/libraries/gateway.yaml
+++ b/charts/haproxy-template-ic/libraries/gateway.yaml
@@ -49,7 +49,7 @@ watchedResources:
 
 templateSnippets:
   # Route analysis system - collects and analyzes all routes for conflicts
-  analyze_routes:
+  util-analyze-routes:
     template: |
       {%- macro analyze_routes(result, resources) %}
         {#-
@@ -272,11 +272,11 @@ templateSnippets:
         {%- set result.all_routes = ns_all.routes %}
       {%- endmacro %}
 
-  resource_gateway_backend-name:
+  util-backend-name-gateway:
     template: >-
       {{- "" -}}gtw_{{ route.metadata.namespace }}_{{ route.metadata.name }}_{{ backend.name }}_{{ backend.port }}
 
-  generate_gateway_backends_macro:
+  util-generate-backends-gateway:
     template: |
       {#- Macro to generate backends for Gateway API routes (HTTPRoute/GRPCRoute) #}
       {#- Deduplicates backends across all routes using shared namespace.seen tracking #}
@@ -294,14 +294,14 @@ templateSnippets:
       {%- if ("|" ~ backend_key ~ "|") not in ns.seen %}
       {%- set ns.seen = ns.seen ~ "|" ~ backend_key ~ "|" %}
 
-      backend {%+ include "resource_gateway_backend-name" +%}
+      backend {%+ include "util-backend-name-gateway" +%}
         balance roundrobin
         default-server check{{ " proto " ~ proto_flag if proto_flag else "" }}
         {%- filter indent(2, first=True) %}
-        {% include "backend-annotations" %}
+        {% include "backend-directives" %}
         {% set service_name = backend.name %}
         {% set port = backend.port %}
-        {% include "backend-servers" %}
+        {% include "util-backend-servers" %}
         {%- endfilter %}
       {%- endif %}
       {%- endfor %}
@@ -310,18 +310,18 @@ templateSnippets:
       {%- endfor %}
       {%- endmacro -%}
 
-  resource_gateway_backends:
+  backends-gateway:
     template: |
       {#- Generate backend definitions from HTTPRoute and GRPCRoute resources #}
+      {#- Implements backends-* extension point from base library #}
       {#- Deduplicates backends: one backend per unique (namespace, route, service, port) combination #}
-      {#- Usage: {% include "resource_gateway_backends" %} #}
 
       {#- Import backend generation macro #}
-      {%- from "generate_gateway_backends_macro" import generate_gateway_backends %}
+      {%- from "util-generate-backends-gateway" import generate_gateway_backends %}
 
       {#- Use namespace with string tracking for seen backends (shared across both route types) #}
       {%- set ns = namespace(seen="") %}
-      # gateway/resource_gateway_backends
+      # gateway/backends-gateway
 
       {#- HTTPRoute backends (HTTP protocol) #}
       {{- generate_gateway_backends(resources.httproutes.List(), "", ns) -}}
@@ -329,19 +329,19 @@ templateSnippets:
       {#- GRPCRoute backends (HTTP/2 protocol) #}
       {{- generate_gateway_backends(resources.grpcroutes.List(), "h2", ns) -}}
 
-  resource_gateway_path-map-entry:
+  util-path-map-entry-gateway:
     template: |
       {#- Generate HTTPRoute path matching map entries with qualifiers #}
       {#- Single backend: BACKEND:<backend_name> #}
       {#- Multiple backends: MULTIBACKEND:<total_weight>:<route_key> #}
       {#- Conflicting paths: GW_ROUTE_ID:<route_type>:<route_ids> #}
-      {#- Usage: {% include "resource_gateway_path-map-entry" with context %} where path_type = "Exact" or "PathPrefix" #}
-      # gateway/resource_gateway_path-map-entry
+      {#- Usage: {% include "util-path-map-entry-gateway" with context %} where path_type = "Exact" or "PathPrefix" #}
+      # gateway/util-path-map-entry-gateway
 
       {#- Compute route analysis once per render (cached across all includes) #}
       {%- set analysis = namespace(path_groups={}, sorted_routes=[], all_routes=[]) %}
       {%- compute_once analysis %}
-        {%- from "analyze_routes" import analyze_routes %}
+        {%- from "util-analyze-routes" import analyze_routes %}
         {{- analyze_routes(analysis, resources) -}}
       {%- endcompute_once %}
 
@@ -367,7 +367,7 @@ templateSnippets:
         {%- endif %}
       {%- endfor %}
 
-  generate_host_map_macro:
+  util-generate-host-map-gateway:
     template: |
       {#- Macro to generate host map entries for Gateway API routes #}
       {#- Parameters: #}
@@ -385,42 +385,42 @@ templateSnippets:
       {%- endfor %}
       {%- endmacro -%}
 
-  map-entry-host-gateway:
+  map-host-gateway:
     template: |
       {#- Generate host map entries for Gateway API routes #}
-      {%- from "generate_host_map_macro" import generate_host_map %}
-      # gateway/map-entry-host-gateway
+      {%- from "util-generate-host-map-gateway" import generate_host_map %}
+      # gateway/map-host-gateway
       {{- generate_host_map(resources.httproutes.List(), "HTTPRoute") -}}
       {{- generate_host_map(resources.grpcroutes.List(), "GRPCRoute") -}}
 
-  map-entry-path-exact-gateway:
+  map-path-exact-gateway:
     template: |
       {#- Generate exact path map entries for HTTPRoute #}
-      # gateway/map-entry-path-exact-gateway
+      # gateway/map-path-exact-gateway
       {% set path_type = "Exact" %}
       {%- set suffix = "" %}
-      {% include "resource_gateway_path-map-entry" %}
+      {% include "util-path-map-entry-gateway" %}
 
-  map-entry-path-prefix-exact-gateway:
+  map-path-prefix-exact-gateway:
     template: |
       {#- Generate prefix-exact path map entries for HTTPRoute #}
-      # gateway/map-entry-path-prefix-exact-gateway
+      # gateway/map-path-prefix-exact-gateway
       {% set path_type = "PathPrefix" %}
       {%- set suffix = "" %}
-      {% include "resource_gateway_path-map-entry" %}
+      {% include "util-path-map-entry-gateway" %}
 
-  map-entry-path-prefix-beg-gateway:
+  map-path-prefix-gateway:
     template: |
       {#- Generate prefix path map entries with trailing slash for HTTPRoute #}
-      # gateway/map-entry-path-prefix-beg-gateway
+      # gateway/map-path-prefix-gateway
       {% set path_type = "PathPrefix" %}
       {%- set suffix = "/" %}
-      {% include "resource_gateway_path-map-entry" %}
+      {% include "util-path-map-entry-gateway" %}
 
-  map-entry-path-regex-gateway:
+  map-path-regex-gateway:
     template: |
       {#- Generate regex path map entries for HTTPRoute with RegularExpression type #}
-      # gateway/map-entry-path-regex-gateway
+      # gateway/map-path-regex-gateway
       {%- for route in resources.httproutes.List() %}
       {#- Count regex path entries for this route -#}
       {%- set ns_outer = namespace(entry_count=0) %}
@@ -445,7 +445,7 @@ templateSnippets:
       {%- set backend = {"name": first_backend.name, "port": first_backend.port} %}
       {%- for match in (rule.matches | default([{}])) %}
       {%- if match.path and match.path.type == "RegularExpression" %}
-      {{ hostname }}{{ match.path.value | default("/") }} {% include "resource_gateway_backend-name" %}
+      {{ hostname }}{{ match.path.value | default("/") }} {% include "util-backend-name-gateway" %}
       {% endif %}
       {%- endfor %}
       {%- endif %}
@@ -453,13 +453,13 @@ templateSnippets:
       {%- endfor %}
       {%- endfor %}
 
-  map-entries-weighted-multi-backend-gateway:
+  map-weighted-backend-gateway:
     template: |
       {#- Generate expanded weighted backend entries for HTTPRoute #}
       {#- Format: <random_number>:<route_key> <backend_name> #}
       {#- Each weight N generates N consecutive entries pointing to same backend #}
       {#- This allows O(1) weighted selection via single map lookup #}
-      # gateway/map-entries-weighted-multi-backend-gateway
+      # gateway/map-weighted-backend-gateway
 
       {%- for route in resources.httproutes.List() %}
       {#- Count weighted rules for this route -#}
@@ -485,7 +485,7 @@ templateSnippets:
 
             {#- Generate <weight> consecutive entries for this backend -#}
             {%- for i in range(ns.cumulative, ns.cumulative + weight) -%}
-      {{ i }}:{{ route_key }} {{ "" }}{% include "resource_gateway_backend-name" %}{{ "\n" -}}
+      {{ i }}:{{ route_key }} {{ "" }}{% include "util-backend-name-gateway" %}{{ "\n" -}}
             {%- endfor %}
 
             {%- set ns.cumulative = ns.cumulative + weight %}
@@ -497,30 +497,31 @@ templateSnippets:
       {%- endfor %}
       {%- endfor %}
 
-  # Advanced matcher setup - processes GW_ROUTE_ID qualifier (runs early via 000 prefix)
-  advanced-matcher-000-gw-route-id-setup:
+  # Advanced matcher setup - processes GW_ROUTE_ID qualifier (runs early via priority)
+  frontend-matchers-advanced-gateway-route-id-setup:
+    priority: 10
     template: |
       {#- Process GW_ROUTE_ID qualifier to extract route type and route ID #}
       {#- Format: GW_ROUTE_ID:<route_type>:<route_ids> #}
       {#- Example: GW_ROUTE_ID:http:ns1_route1_0__ns2_route2_1 #}
-      {#- This runs early (000 prefix) to set variables used by later matchers #}
-      # gateway/advanced-matcher-000-gw-route-id-setup
+      {#- This runs early (priority 10) to set variables used by later matchers #}
+      # gateway/frontend-matchers-advanced-gateway-route-id-setup
       http-request set-var(req.gw_route_type) var(txn.path_match),field(2,:) if { var(txn.path_match),field(1,:) -m str GW_ROUTE_ID }
       http-request set-var(req.gw_route_id) var(txn.path_match),field(3,:) if { var(txn.path_match),field(1,:) -m str GW_ROUTE_ID }
 
   # Advanced matcher generator - creates http-request statements for method/header/query matching
-  advanced-matcher-gateway:
+  frontend-matchers-advanced-gateway:
     template: |
       {#- Generate http-request statements for routes with advanced matchers #}
       {#- This is injected into base template via the advanced-matcher-* extension point #}
       # gateway/advanced-matcher-gateway
 
-      {%- from "regex-sanitize" import sanitize_regex %}
+      {%- from "util-regex-sanitize" import sanitize_regex %}
 
       {#- Compute route analysis once per render (cached across all includes) #}
       {%- set analysis = namespace(path_groups={}, sorted_routes=[], all_routes=[]) %}
       {%- compute_once analysis %}
-        {%- from "analyze_routes" import analyze_routes %}
+        {%- from "util-analyze-routes" import analyze_routes %}
         {{- analyze_routes(analysis, resources) -}}
       {%- endcompute_once %}
 
@@ -603,15 +604,16 @@ templateSnippets:
       {%- endif %}
 
   # Path match setting - sets txn.path_match based on winning rule ID
-  advanced-matcher-zzz-path-match-gateway:
+  frontend-matchers-advanced-gateway-path-match:
+    priority: 900
     template: |
       {#- Set txn.path_match for backend selection based on winning rule #}
-      {#- Runs after advanced-matcher-gateway sets req.gw_rule_id (zzz ensures late ordering) #}
-      # gateway/advanced-matcher-zzz-path-match-gateway
+      {#- Runs after frontend-matchers-advanced-gateway sets req.gw_rule_id (priority ensures late ordering) #}
+      # gateway/frontend-matchers-advanced-gateway-path-match
 
       {%- set analysis = namespace(path_groups={}, sorted_routes=[], all_routes=[]) %}
       {%- compute_once analysis %}
-        {%- from "analyze_routes" import analyze_routes %}
+        {%- from "util-analyze-routes" import analyze_routes %}
         {{- analyze_routes(analysis, resources) -}}
       {%- endcompute_once %}
 
@@ -639,19 +641,19 @@ templateSnippets:
       {%- endif %}
 
   # Filter: RequestHeaderModifier - modifies request headers before backend selection
-  advanced-matcher-filter-request-header:
+  frontend-filters-gateway-request-header:
     template: |
       {#- Generate http-request header modification statements #}
-      {#- This is injected into base template via the advanced-matcher-* extension point #}
-      {#- Runs AFTER advanced-matcher-gateway due to alphabetical ordering #}
-      # gateway/advanced-matcher-filter-request-header
+      {#- This is injected into base template via the frontend-filters-* extension point #}
+      {#- Runs AFTER routing decisions, BEFORE backend selection #}
+      # gateway/frontend-filters-gateway-request-header
 
-      {%- from "regex-sanitize" import sanitize_regex %}
+      {%- from "util-regex-sanitize" import sanitize_regex %}
 
       {#- Compute route analysis once per render (cached across all includes) #}
       {%- set analysis = namespace(path_groups={}, sorted_routes=[], all_routes=[]) %}
       {%- compute_once analysis %}
-        {%- from "analyze_routes" import analyze_routes %}
+        {%- from "util-analyze-routes" import analyze_routes %}
         {{- analyze_routes(analysis, resources) -}}
       {%- endcompute_once %}
 
@@ -701,19 +703,19 @@ templateSnippets:
       {%- endif %}
 
   # Filter: ResponseHeaderModifier - modifies response headers before sending to client
-  advanced-matcher-filter-response-header:
+  frontend-filters-gateway-response-header:
     template: |
       {#- Generate http-response header modification statements #}
-      {#- This is injected into base template via the advanced-matcher-* extension point #}
-      {#- Runs AFTER request filters due to alphabetical ordering #}
-      # gateway/advanced-matcher-filter-response-header
+      {#- This is injected into base template via the frontend-filters-* extension point #}
+      {#- Runs AFTER routing decisions, BEFORE backend selection #}
+      # gateway/frontend-filters-gateway-response-header
 
-      {%- from "regex-sanitize" import sanitize_regex %}
+      {%- from "util-regex-sanitize" import sanitize_regex %}
 
       {#- Compute route analysis once per render (cached across all includes) #}
       {%- set analysis = namespace(path_groups={}, sorted_routes=[], all_routes=[]) %}
       {%- compute_once analysis %}
-        {%- from "analyze_routes" import analyze_routes %}
+        {%- from "util-analyze-routes" import analyze_routes %}
         {{- analyze_routes(analysis, resources) -}}
       {%- endcompute_once %}
 
@@ -763,19 +765,19 @@ templateSnippets:
       {%- endif %}
 
   # Filter: RequestRedirect - redirects requests to different locations
-  advanced-matcher-filter-redirect:
+  frontend-filters-gateway-redirect:
     template: |
       {#- Generate http-request redirect statements #}
-      {#- This is injected into base template via the advanced-matcher-* extension point #}
-      {#- Runs AFTER header filters, BEFORE backend selection #}
-      # gateway/advanced-matcher-filter-redirect
+      {#- This is injected into base template via the frontend-filters-* extension point #}
+      {#- Runs AFTER routing decisions, BEFORE backend selection #}
+      # gateway/frontend-filters-gateway-redirect
 
-      {%- from "regex-sanitize" import sanitize_regex %}
+      {%- from "util-regex-sanitize" import sanitize_regex %}
 
       {#- Compute route analysis once per render (cached across all includes) #}
       {%- set analysis = namespace(path_groups={}, sorted_routes=[], all_routes=[]) %}
       {%- compute_once analysis %}
-        {%- from "analyze_routes" import analyze_routes %}
+        {%- from "util-analyze-routes" import analyze_routes %}
         {{- analyze_routes(analysis, resources) -}}
       {%- endcompute_once %}
 
@@ -857,19 +859,19 @@ templateSnippets:
       {%- endif %}
 
   # Filter: URLRewrite - rewrites request URLs before sending to backend
-  advanced-matcher-filter-urlrewrite:
+  frontend-filters-gateway-urlrewrite:
     template: |
       {#- Generate http-request URL rewrite statements #}
-      {#- This is injected into base template via the advanced-matcher-* extension point #}
-      {#- Runs AFTER redirect filters, BEFORE backend selection #}
-      # gateway/advanced-matcher-filter-urlrewrite
+      {#- This is injected into base template via the frontend-filters-* extension point #}
+      {#- Runs AFTER routing decisions, BEFORE backend selection #}
+      # gateway/frontend-filters-gateway-urlrewrite
 
-      {%- from "regex-sanitize" import sanitize_regex %}
+      {%- from "util-regex-sanitize" import sanitize_regex %}
 
       {#- Compute route analysis once per render (cached across all includes) #}
       {%- set analysis = namespace(path_groups={}, sorted_routes=[], all_routes=[]) %}
       {%- compute_once analysis %}
-        {%- from "analyze_routes" import analyze_routes %}
+        {%- from "util-analyze-routes" import analyze_routes %}
         {{- analyze_routes(analysis, resources) -}}
       {%- endcompute_once %}
 

--- a/charts/haproxy-template-ic/libraries/haproxytech.yaml
+++ b/charts/haproxy-template-ic/libraries/haproxytech.yaml
@@ -2,7 +2,7 @@
 # Contains template snippets for haproxy.org/* annotations and corresponding validation tests
 
 templateSnippets:
-  auth-userlist-name:
+  util-auth-userlist-name:
     template: >-
       {%- macro get_userlist_name(auth_secret, namespace) -%}
       {%- if "/" in auth_secret -%}
@@ -12,7 +12,7 @@ templateSnippets:
       {%- endif -%}
       {%- endmacro -%}
 
-  top-level-annotation-haproxytech-auth:
+  global-top-haproxytech-auth:
     priority: 500
     template: |
       {#-
@@ -65,7 +65,7 @@ templateSnippets:
           {%- set auth_secret = ingress.metadata.annotations["haproxy.org/auth-secret"] | default("") %}
           {%- if auth_secret %}
             {#- Generate userlist name using macro #}
-            {%- include "auth-userlist-name" -%}
+            {%- include "util-auth-userlist-name" -%}
             {%- set userlist_name = get_userlist_name(auth_secret, ingress.metadata.namespace) | trim -%}
 
             {#- Only process each userlist once #}
@@ -84,7 +84,7 @@ templateSnippets:
               {#- Fetch secret from store #}
               {%- set secret = resources.secrets.GetSingle(secret_namespace, secret_name) %}
               {%- if secret %}
-      # haproxytech/top-level-annotation-haproxytech-auth
+      # haproxytech/global-top-haproxytech-auth
 
       userlist {{ userlist_name }}
                 {%- for username in secret.data | default({}) %}
@@ -98,7 +98,7 @@ templateSnippets:
         {%- endif %}
       {%- endfor %}
 
-  backend-annotation-haproxytech-auth:
+  backend-directives-haproxytech-auth:
     priority: 500
     template: |
       {#-
@@ -126,9 +126,9 @@ templateSnippets:
         {%- set auth_realm = ingress.metadata.annotations["haproxy.org/auth-realm"] | default("RestrictedArea") %}
         {%- if auth_secret %}
           {#- Generate userlist name using macro #}
-          {%- include "auth-userlist-name" -%}
+          {%- include "util-auth-userlist-name" -%}
           {%- set userlist_name = get_userlist_name(auth_secret, ingress.metadata.namespace) | trim -%}
-      # haproxytech/backend-annotation-haproxytech-auth
+      # haproxytech/backend-directives-haproxytech-auth
       http-request auth realm "{{ auth_realm }}" unless { http_auth({{ userlist_name }}) }
         {%- endif %}
       {%- endif %}

--- a/charts/haproxy-template-ic/libraries/ingress.yaml
+++ b/charts/haproxy-template-ic/libraries/ingress.yaml
@@ -21,14 +21,14 @@ watchedResources:
     indexBy: ["metadata.namespace", "metadata.labels.kubernetes\\.io/service-name"]
 
 templateSnippets:
-  resource_ingress_backend-name:
+  util-backend-name-ingress:
     template: >-
       {{- "" -}}ing_{{ ingress.metadata.namespace }}_{{ ingress.metadata.name }}_{{ path.backend.service.name }}_{{ path.backend.service.port.name | default(path.backend.service.port.number) }}
 
-  resource_ingress_path-map-entry:
+  util-path-map-entry-ingress:
     template: |
       {#- Generate map entries for paths matching specified pathTypes #}
-      {#- Usage: {% include "resource_ingress_path-map-entry" with context %} where path_types = ["Exact"] or ["Prefix", "ImplementationSpecific"] #}
+      {#- Usage: {% include "util-path-map-entry-ingress" with context %} where path_types = ["Exact"] or ["Prefix", "ImplementationSpecific"] #}
       {%- for ingress in resources.ingresses.List() %}
       {#- Count matching paths for this ingress -#}
       {%- set ns_paths = namespace(all_paths=[]) %}
@@ -47,7 +47,7 @@ templateSnippets:
       {%- for path in (rule.http.paths | default([]) | selectattr("path", "defined")) %}
       {%- for check_type in path_types %}
       {%- if path.pathType == check_type %}
-      {{ "\n" }}{{ rule.host }}{{ path.path }} BACKEND:{% include "resource_ingress_backend-name" -%}{{ suffix }}
+      {{ "\n" }}{{ rule.host }}{{ path.path }} BACKEND:{% include "util-backend-name-ingress" -%}{{ suffix }}
       {%- endif %}
       {%- endfor %}
       {% endfor %}
@@ -55,15 +55,15 @@ templateSnippets:
       {%- endif %}
       {%- endfor %}
 
-  resource_ingress_backends:
+  backends-ingress:
     template: |
       {#- Generate all backend definitions from ingress resources #}
-      {#- Usage: {% include "resource_ingress_backends" %} #}
+      {#- Implements backends-* extension point from base library #}
       {#- Deduplicate backends: multiple paths to same service+port share one backend #}
       {%- set ns = namespace(seen=[]) %}
       {%- for ingress in resources.ingresses.List() -%}
       {%- if loop.first %}
-      # ingress/resource_ingress_backends
+      # ingress/backends-ingress
       {%- endif %}
       {%- if ingress.spec and ingress.spec.rules %}
       {%- for rule in ingress.spec.rules %}
@@ -72,18 +72,18 @@ templateSnippets:
       {%- if path.backend and path.backend.service %}
       {%- set service_name = path.backend.service.name %}
       {%- set port = path.backend.service.port.number | default(80) %}
-      {#- Compute backend key for deduplication (matches resource_ingress_backend-name) #}
+      {#- Compute backend key for deduplication (matches util-backend-name-ingress) #}
       {%- set backend_key = ingress.metadata.namespace ~ "_" ~ ingress.metadata.name ~ "_" ~ path.backend.service.name ~ "_" ~ (path.backend.service.port.name | default(path.backend.service.port.number)) %}
       {%- if backend_key not in ns.seen %}
       {%- set ns.seen = ns.seen.append(backend_key) %}
 
-      backend {%+ include "resource_ingress_backend-name" +%}
+      backend {%+ include "util-backend-name-ingress" +%}
         balance roundrobin
         option httpchk GET {{ path.path | default('/') }}
         default-server check
         {%- filter indent(2, first=True) %}
-        {% include "backend-annotations" %}
-        {% include "backend-servers" %}
+        {% include "backend-directives" %}
+        {% include "util-backend-servers" %}
         {%- endfilter %}
       {%- endif %}
       {%- endif %}
@@ -93,12 +93,13 @@ templateSnippets:
       {%- endif %}
       {%- endfor %}
 
-  map-entry-host-ingress:
+  map-host-ingress:
     template: |
       {#- Generate host map entries for Ingress resources #}
+      {#- Implements map-host-* extension point from base library #}
       {%- for ingress in resources.ingresses.List() -%}
       {%- if loop.first %}
-      # ingress/map-entry-host-ingress
+      # ingress/map-host-ingress
       {%- endif %}
       {%- set rules_with_http = ingress.spec.rules | default([]) | selectattr("http", "defined") | list %}
       {%- if rules_with_http | length > 0 %}
@@ -110,29 +111,32 @@ templateSnippets:
       {%- endif %}
       {%- endfor %}
 
-  map-entry-path-exact-ingress:
+  map-path-exact-ingress:
     template: |
       {#- Generate exact path map entries for Ingress resources #}
-      # ingress/map-entry-path-exact-ingress
+      {#- Implements map-path-exact-* extension point from base library #}
+      # ingress/map-path-exact-ingress
       {% set path_types = ["Exact"] %}
       {%- set suffix = "" %}
-      {% include "resource_ingress_path-map-entry" %}
+      {% include "util-path-map-entry-ingress" %}
 
-  map-entry-path-prefix-exact-ingress:
+  map-path-prefix-exact-ingress:
     template: |
       {#- Generate prefix-exact path map entries for Ingress resources #}
-      # ingress/map-entry-path-prefix-exact-ingress
+      {#- Implements map-path-prefix-exact-* extension point from base library #}
+      # ingress/map-path-prefix-exact-ingress
       {% set path_types = ["Prefix", "ImplementationSpecific"] %}
       {%- set suffix = "" %}
-      {% include "resource_ingress_path-map-entry" %}
+      {% include "util-path-map-entry-ingress" %}
 
-  map-entry-path-prefix-beg-ingress:
+  map-path-prefix-ingress:
     template: |
       {#- Generate prefix path map entries with trailing slash for Ingress resources #}
-      # ingress/map-entry-path-prefix-beg-ingress
+      {#- Implements map-path-prefix-* extension point from base library #}
+      # ingress/map-path-prefix-ingress
       {% set path_types = ["Prefix", "ImplementationSpecific"] %}
       {%- set suffix = "/" %}
-      {% include "resource_ingress_path-map-entry" %}
+      {% include "util-path-map-entry-ingress" %}
 
 validationTests:
   test-ingress-duplicate-backend-different-ports:

--- a/charts/haproxy-template-ic/libraries/path-regex-last.yaml
+++ b/charts/haproxy-template-ic/libraries/path-regex-last.yaml
@@ -14,12 +14,12 @@
 #         enabled: true
 
 templateSnippets:
-  use-backend-selection:
+  frontend-routing-logic:
     template: |
-      {#- Backend selection logic with qualifier system and performance-first ordering #}
+      {#- Frontend routing logic with qualifier system and performance-first ordering #}
       {#- Supports BACKEND and MULTIBACKEND qualifiers #}
       {#- Overrides base library: Exact > Prefix > Regex (regex moved to last) #}
-      # path-regex-last/use-backend-selection
+      # path-regex-last/frontend-routing-logic
 
       # Set variables for path-based routing
       http-request set-var(txn.base) base

--- a/scripts/test-routes.sh
+++ b/scripts/test-routes.sh
@@ -1,0 +1,671 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Test script for HAProxy Template Ingress Controller
+# Tests all Ingresses and HTTPRoutes in the dev environment
+
+# Ensure we operate from the repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Configuration
+CLUSTER_NAME="haproxy-template-ic-dev"
+ECHO_NAMESPACE="echo"
+NODEPORT="30080"
+BASE_URL="http://localhost:${NODEPORT}"
+
+# Options
+VERBOSE=false
+TEST_FILTER=""
+INGRESS_ONLY=false
+HTTPROUTE_ONLY=false
+
+# Colors
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+BLUE="\033[0;34m"
+NC="\033[0m"
+
+# Test statistics
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+# Logging functions
+log() {
+    local level msg
+    level="$1"; shift
+    msg="$*"
+    echo -e "${BLUE}[$(date +'%Y-%m-%dT%H:%M:%S%z')]${NC} ${level}: ${msg}"
+}
+
+ok() {
+    echo -e "${GREEN}✔${NC} $*"
+    PASSED_TESTS=$((PASSED_TESTS + 1))
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+}
+
+warn() {
+    echo -e "${YELLOW}⚠${NC} $*"
+}
+
+err() {
+    echo -e "${RED}✖${NC} $*"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+}
+
+debug() {
+    [[ "$VERBOSE" == "true" ]] && echo -e "${BLUE}[DEBUG]${NC} $*" || true
+}
+
+print_section() {
+    echo
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo " $1"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+show_usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Test all Ingresses and HTTPRoutes in the dev environment.
+
+OPTIONS:
+    --test NAME         Test only a specific route (ingress or httproute name)
+    --ingress-only      Test only Ingress resources
+    --httproute-only    Test only HTTPRoute resources
+    --verbose           Enable debug output
+    --help, -h          Show this help
+
+EXAMPLES:
+    $0                          # Test all routes
+    $0 --test echo-basic        # Test only echo-basic HTTPRoute
+    $0 --test echo-server-auth  # Test only auth ingress
+    $0 --ingress-only           # Test only Ingress resources
+    $0 --httproute-only         # Test only HTTPRoute resources
+    $0 --verbose                # Run with debug output
+
+EXIT CODES:
+    0   All tests passed
+    1   One or more tests failed
+
+EOF
+}
+
+# Test assertion helpers
+assert_response_ok() {
+    local description="$1"
+    local host="$2"
+    local path="${3:-/}"
+    local expected_backend="${4:-}"
+    shift 4
+    local extra_args=("$@")
+
+    debug "Testing: $description"
+    debug "  Host: $host, Path: $path"
+    debug "  Extra args: ${extra_args[*]}"
+
+    local response
+    if ! response=$(curl -s --max-time 5 -H "Host: $host" "${extra_args[@]}" "${BASE_URL}${path}" 2>&1); then
+        err "$description - Connection failed"
+        return 1
+    fi
+
+    debug "  Response: ${response:0:200}..."
+
+    # Check for expected backend if specified
+    if [[ -n "$expected_backend" ]]; then
+        if echo "$response" | grep -q "\"ENVIRONMENT\":\"$expected_backend\""; then
+            ok "$description - Routed to $expected_backend"
+        elif echo "$response" | grep -q "\"ENVIRONMENT\""; then
+            local actual_backend=$(echo "$response" | grep -o '"ENVIRONMENT":"[^"]*"' | cut -d'"' -f4)
+            err "$description - Expected backend '$expected_backend', got '$actual_backend'"
+            return 1
+        else
+            ok "$description - Routed to default backend"
+        fi
+    else
+        # Just check for successful response
+        if echo "$response" | grep -q "\"http\":"; then
+            ok "$description - Response OK"
+        else
+            err "$description - Invalid response"
+            echo "  Received: ${response:0:500}"
+            return 1
+        fi
+    fi
+}
+
+assert_weighted_distribution() {
+    local description="$1"
+    local host="$2"
+    local expected_default_pct="$3"
+    local expected_v2_pct="$4"
+    local num_requests="${5:-20}"
+    local tolerance="${6:-10}"
+
+    debug "Testing weighted distribution: $description"
+    debug "  Host: $host, Requests: $num_requests"
+    debug "  Expected: ${expected_default_pct}% default, ${expected_v2_pct}% v2"
+
+    local count_default=0
+    local count_v2=0
+
+    for i in $(seq 1 "$num_requests"); do
+        local response
+        response=$(curl -s --max-time 5 -H "Host: $host" "${BASE_URL}/" 2>&1)
+
+        if echo "$response" | grep -q '"ENVIRONMENT":"v2"'; then
+            count_v2=$((count_v2 + 1))
+        else
+            count_default=$((count_default + 1))
+        fi
+    done
+
+    local actual_default_pct=$(( (count_default * 100) / num_requests ))
+    local actual_v2_pct=$(( (count_v2 * 100) / num_requests ))
+
+    debug "  Actual: ${actual_default_pct}% default ($count_default/$num_requests), ${actual_v2_pct}% v2 ($count_v2/$num_requests)"
+
+    # Check if within tolerance
+    local default_diff=$(( actual_default_pct - expected_default_pct ))
+    default_diff=${default_diff#-}  # absolute value
+    local v2_diff=$(( actual_v2_pct - expected_v2_pct ))
+    v2_diff=${v2_diff#-}
+
+    if [[ $default_diff -le $tolerance ]] && [[ $v2_diff -le $tolerance ]]; then
+        ok "$description - Distribution OK (${actual_default_pct}% default, ${actual_v2_pct}% v2)"
+    else
+        err "$description - Distribution out of range (${actual_default_pct}% default, ${actual_v2_pct}% v2, expected ${expected_default_pct}%/${expected_v2_pct}% ±${tolerance}%)"
+        return 1
+    fi
+}
+
+assert_auth_required() {
+    local description="$1"
+    local host="$2"
+
+    debug "Testing auth requirement: $description"
+
+    local response_code
+    response_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Host: $host" "${BASE_URL}/" 2>&1)
+
+    if [[ "$response_code" == "401" ]]; then
+        ok "$description - Auth required (401)"
+    else
+        err "$description - Expected 401, got $response_code"
+        return 1
+    fi
+}
+
+assert_auth_success() {
+    local description="$1"
+    local host="$2"
+    local username="$3"
+    local password="$4"
+
+    debug "Testing auth success: $description"
+
+    local response
+    if ! response=$(curl -s --max-time 5 -u "$username:$password" -H "Host: $host" "${BASE_URL}/" 2>&1); then
+        err "$description - Connection failed"
+        return 1
+    fi
+
+    if echo "$response" | grep -q "\"http\":"; then
+        ok "$description - Auth successful with $username:$password"
+    else
+        err "$description - Auth failed"
+        echo "  Received: ${response:0:500}"
+        return 1
+    fi
+}
+
+# Verify cluster is accessible
+verify_cluster() {
+    if ! kind get clusters 2>/dev/null | grep -q "$CLUSTER_NAME"; then
+        echo -e "${RED}Error:${NC} Kind cluster '$CLUSTER_NAME' not found"
+        echo "Start the dev environment with: ./scripts/start-dev-env.sh"
+        exit 1
+    fi
+
+    if ! kubectl --context "kind-$CLUSTER_NAME" cluster-info &>/dev/null; then
+        echo -e "${RED}Error:${NC} Cannot access cluster 'kind-$CLUSTER_NAME'"
+        exit 1
+    fi
+
+    debug "Cluster verified: kind-$CLUSTER_NAME"
+}
+
+# Wait for services to be ready and accepting connections
+wait_for_services_ready() {
+    log INFO "Waiting for services to be ready..."
+
+    local max_attempts=10
+    local delay=2
+    local attempt=1
+    local ready=false
+
+    # Test basic ingress connectivity (echo.localdev.me)
+    while [[ $attempt -le $max_attempts ]]; do
+        debug "Readiness check attempt $attempt/$max_attempts..."
+
+        local response
+        if response=$(curl -s --max-time 5 -H "Host: echo.localdev.me" "${BASE_URL}/" 2>&1); then
+            # Check that response contains valid JSON with expected structure
+            if echo "$response" | grep -q "\"http\":"; then
+                debug "Services responding with valid JSON"
+                ready=true
+                break
+            else
+                debug "Connection succeeded but response invalid or empty"
+            fi
+        else
+            debug "Connection failed"
+        fi
+
+        if [[ $attempt -lt $max_attempts ]]; then
+            debug "Services not ready yet, waiting ${delay}s before retry..."
+            sleep "$delay"
+        fi
+
+        attempt=$((attempt + 1))
+    done
+
+    if [[ "$ready" == "true" ]]; then
+        ok "Services are ready and accepting connections"
+    else
+        echo
+        err "Services did not become ready after $max_attempts attempts (${max_attempts}x${delay}s)"
+        echo
+        echo "This typically means:"
+        echo "  - HAProxy pods are not running or not ready"
+        echo "  - Echo service pods are not ready"
+        echo "  - HAProxy configuration has not synced yet"
+        echo "  - Endpoints have not been populated"
+        echo
+        echo "Troubleshooting steps:"
+        echo "  1. Check HAProxy pods: kubectl -n haproxy-template-ic get pods -l app=haproxy"
+        echo "  2. Check echo pods: kubectl -n echo get pods"
+        echo "  3. Check HAProxy logs: kubectl -n haproxy-template-ic logs deploy/haproxy-production -c haproxy"
+        echo "  4. Check controller logs: ./scripts/start-dev-env.sh logs"
+        echo "  5. Check endpoints: kubectl -n echo get endpoints"
+        echo "  6. Wait longer and try again, or restart: ./scripts/start-dev-env.sh restart"
+        echo
+        exit 1
+    fi
+}
+
+should_test() {
+    local resource_name="$1"
+
+    if [[ -n "$TEST_FILTER" ]]; then
+        [[ "$resource_name" == "$TEST_FILTER" ]]
+    else
+        true
+    fi
+}
+
+#═══════════════════════════════════════════════════════════════════════════
+# INGRESS TESTS
+#═══════════════════════════════════════════════════════════════════════════
+
+test_ingress_basic() {
+    if ! should_test "echo-server"; then
+        return 0
+    fi
+
+    print_section "Testing Ingress: echo-server (echo.localdev.me)"
+
+    assert_response_ok \
+        "Basic ingress routing" \
+        "echo.localdev.me" \
+        "/" \
+        ""
+}
+
+test_ingress_auth() {
+    if ! should_test "echo-server-auth"; then
+        return 0
+    fi
+
+    print_section "Testing Ingress: echo-server-auth (echo-auth.localdev.me)"
+
+    assert_auth_required \
+        "Auth required without credentials" \
+        "echo-auth.localdev.me"
+
+    assert_auth_success \
+        "Auth with admin:admin" \
+        "echo-auth.localdev.me" \
+        "admin" \
+        "admin"
+
+    assert_auth_success \
+        "Auth with user:password" \
+        "echo-auth.localdev.me" \
+        "user" \
+        "password"
+}
+
+#═══════════════════════════════════════════════════════════════════════════
+# HTTPROUTE TESTS
+#═══════════════════════════════════════════════════════════════════════════
+
+test_httproute_basic() {
+    if ! should_test "echo-basic"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-basic"
+
+    assert_response_ok \
+        "Basic PathPrefix routing" \
+        "echo-gateway.localdev.me" \
+        "/" \
+        ""
+}
+
+test_httproute_paths() {
+    if ! should_test "echo-paths"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-paths"
+
+    assert_response_ok \
+        "Exact path match /exact" \
+        "echo-paths.localdev.me" \
+        "/exact" \
+        ""
+
+    assert_response_ok \
+        "Prefix path match /api/test" \
+        "echo-paths.localdev.me" \
+        "/api/test" \
+        ""
+
+    assert_response_ok \
+        "Root path /" \
+        "echo-paths.localdev.me" \
+        "/" \
+        ""
+}
+
+test_httproute_methods() {
+    if ! should_test "echo-methods"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-methods"
+
+    assert_response_ok \
+        "GET /api routes to v2" \
+        "echo-methods.localdev.me" \
+        "/api" \
+        "v2" \
+        -X GET
+
+    assert_response_ok \
+        "POST /api routes to default" \
+        "echo-methods.localdev.me" \
+        "/api" \
+        "" \
+        -X POST
+
+    assert_response_ok \
+        "Catch-all /" \
+        "echo-methods.localdev.me" \
+        "/" \
+        "" \
+        -X GET
+}
+
+test_httproute_headers() {
+    if ! should_test "echo-headers"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-headers"
+
+    assert_response_ok \
+        "Exact header X-Api-Version: v2" \
+        "echo-headers.localdev.me" \
+        "/api" \
+        "v2" \
+        -H "X-Api-Version: v2"
+
+    assert_response_ok \
+        "Regex header X-User-Agent: mobile-app" \
+        "echo-headers.localdev.me" \
+        "/api" \
+        "v2" \
+        -H "X-User-Agent: mobile-app"
+
+    assert_response_ok \
+        "No headers - catch-all" \
+        "echo-headers.localdev.me" \
+        "/" \
+        ""
+}
+
+test_httproute_query() {
+    if ! should_test "echo-query"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-query"
+
+    assert_response_ok \
+        "Query param version=beta" \
+        "echo-query.localdev.me" \
+        "/api?version=beta" \
+        "v2"
+
+    assert_response_ok \
+        "Query param debug=true" \
+        "echo-query.localdev.me" \
+        "/api?debug=true" \
+        "v2"
+
+    assert_response_ok \
+        "Query param debug=1" \
+        "echo-query.localdev.me" \
+        "/api?debug=1" \
+        "v2"
+
+    assert_response_ok \
+        "No query params - catch-all" \
+        "echo-query.localdev.me" \
+        "/" \
+        ""
+}
+
+test_httproute_split() {
+    if ! should_test "echo-split"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-split (weighted routing)"
+
+    # Weighted routing uses HAProxy's rand() for load balancing
+    # With larger sample sizes, distribution converges to configured weights
+    # Note: Individual test runs may still show variance due to randomness
+    assert_weighted_distribution \
+        "70/30 traffic split" \
+        "echo-split.localdev.me" \
+        70 \
+        30 \
+        100 \
+        12
+}
+
+test_httproute_precedence() {
+    if ! should_test "echo-precedence"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-precedence"
+
+    assert_response_ok \
+        "Most specific (GET + 2 headers + query)" \
+        "echo-precedence.localdev.me" \
+        "/?debug=true" \
+        "v2" \
+        -X GET \
+        -H "X-Version: v2" \
+        -H "X-Environment: prod"
+
+    assert_response_ok \
+        "Specific (GET + header)" \
+        "echo-precedence.localdev.me" \
+        "/" \
+        "" \
+        -X GET \
+        -H "X-Version: v1"
+
+    assert_response_ok \
+        "Medium (GET only)" \
+        "echo-precedence.localdev.me" \
+        "/" \
+        "v2" \
+        -X GET
+
+    assert_response_ok \
+        "Least specific (catch-all)" \
+        "echo-precedence.localdev.me" \
+        "/" \
+        "" \
+        -X POST
+}
+
+test_httproute_combined() {
+    if ! should_test "echo-combined"; then
+        return 0
+    fi
+
+    print_section "Testing HTTPRoute: echo-combined"
+
+    assert_response_ok \
+        "All matchers (POST + /api + header + query)" \
+        "echo-combined.localdev.me" \
+        "/api?token=secret123" \
+        "v2" \
+        -X POST \
+        -H "Content-Type: application/json"
+
+    assert_response_ok \
+        "Wrong token pattern - catch-all" \
+        "echo-combined.localdev.me" \
+        "/other?token=wrongtoken" \
+        "" \
+        -X POST \
+        -H "Content-Type: application/json"
+
+    assert_response_ok \
+        "Wrong content-type - catch-all" \
+        "echo-combined.localdev.me" \
+        "/other?token=secret123" \
+        "" \
+        -X POST \
+        -H "Content-Type: text/plain"
+
+    assert_response_ok \
+        "Wrong method - catch-all" \
+        "echo-combined.localdev.me" \
+        "/other" \
+        "" \
+        -X GET
+}
+
+#═══════════════════════════════════════════════════════════════════════════
+# MAIN
+#═══════════════════════════════════════════════════════════════════════════
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --test)
+                TEST_FILTER="$2"
+                shift 2
+                ;;
+            --ingress-only)
+                INGRESS_ONLY=true
+                shift
+                ;;
+            --httproute-only)
+                HTTPROUTE_ONLY=true
+                shift
+                ;;
+            --verbose)
+                VERBOSE=true
+                shift
+                ;;
+            --help|-h)
+                show_usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+
+    echo
+    echo "═══════════════════════════════════════════════════════════════════════════"
+    echo " HAProxy Template Ingress Controller - Route Tests"
+    echo "═══════════════════════════════════════════════════════════════════════════"
+    echo
+
+    verify_cluster
+    wait_for_services_ready
+
+    # Run Ingress tests
+    if [[ "$HTTPROUTE_ONLY" != "true" ]]; then
+        test_ingress_basic
+        test_ingress_auth
+    fi
+
+    # Run HTTPRoute tests
+    if [[ "$INGRESS_ONLY" != "true" ]]; then
+        test_httproute_basic
+        test_httproute_paths
+        test_httproute_methods
+        test_httproute_headers
+        test_httproute_query
+        test_httproute_split
+        test_httproute_precedence
+        test_httproute_combined
+    fi
+
+    # Print summary
+    print_section "Test Summary"
+    echo "Total tests:  $TOTAL_TESTS"
+    echo -e "Passed:       ${GREEN}$PASSED_TESTS${NC}"
+    if [[ $FAILED_TESTS -eq 0 ]]; then
+        echo -e "Failed:       ${GREEN}$FAILED_TESTS${NC}"
+    else
+        echo -e "Failed:       ${RED}$FAILED_TESTS${NC}"
+    fi
+    echo
+
+    if [[ $FAILED_TESTS -eq 0 ]]; then
+        echo -e "${GREEN}✔ All tests passed!${NC}"
+        exit 0
+    else
+        echo -e "${RED}✖ $FAILED_TESTS test(s) failed${NC}"
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
This PR refactors template snippet naming for better discoverability and adds comprehensive route testing to CI.

## Template Snippet Naming Refactor

The template snippet naming now uses consistent prefixes to indicate purpose:

**Utility snippets** (general-purpose helpers):
- `macros` → `util-macros`
- `regex-sanitize` → `util-regex-sanitize`  
- `backend-servers` → `util-backend-servers`

**Frontend logic**:
- `use-backend-selection` → `frontend-routing-logic`
- `advanced-matcher-*` → `frontend-matchers-advanced-*`

**Backend directives**:
- `backend-annotations` → `backend-directives`

**Global top-level**:
- `top-level-annotations` → `global-top`

**Map entries**:
- `map-entry-host-*` → `map-host-*`
- `map-entry-path-exact-*` → `map-path-exact-*`
- `map-entry-path-prefix-*` → `map-path-prefix-*`
- `map-entry-path-regex-*` → `map-path-regex-*`
- `map-entries-weighted-multi-backend-*` → `map-weighted-backend-*`

All references updated across library files to maintain compatibility.

## Route Testing

Added `scripts/test-routes.sh` that provides comprehensive testing of:

**Ingress resources:**
- Basic routing to echo service
- Basic authentication (admin:admin, user:password)

**Gateway API HTTPRoutes:**
- Basic routing
- Path matching (exact, prefix)
- HTTP method matching (GET vs POST)
- Header matching (exact, regex)
- Query parameter matching
- Weighted traffic splitting (70/30)
- Route precedence
- Combined matchers (method + headers + query)

**CI Integration:**

Added `test-routes` job to `.github/workflows/ci.yml` that:
- Creates kind cluster
- Builds and deploys controller via dev environment script
- Runs all route tests
- Cleans up cluster on completion

This ensures route functionality is validated on every PR.