### PR TITLE
Update repository references to new organization

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@ haproxy-template-ic
 Copyright 2025 Philipp Hossner
 
 This product includes software developed by
-Philipp Hossner (https://github.com/phihos/haproxy-template-ingress-controller).
+Philipp Hossner (https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller).
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Build Status](https://github.com/phihos/haproxy-template-ingress-controller/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/phihos/haproxy-template-ingress-controller/actions/workflows/ci.yml)
+[![Build Status](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/actions/workflows/ci.yml)
 
 ## Overview
 

--- a/charts/haproxy-template-ic/Chart.yaml
+++ b/charts/haproxy-template-ic/Chart.yaml
@@ -10,16 +10,16 @@ keywords:
   - controller
   - loadbalancer
   - template
-home: https://github.com/phihos/haproxy-template-ingress-controller
+home: https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller
 sources:
-  - https://github.com/phihos/haproxy-template-ingress-controller
+  - https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller
 maintainers:
   - name: phihos
 annotations:
   # Document all component images (Artifact Hub standard)
   artifacthub.io/images: |
     - name: controller
-      image: ghcr.io/phihos/haproxy-template-ic:0.1.0
+      image: ghcr.io/haproxy-template-ic/haproxy-template-ingress-controller:0.1.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -52,9 +52,9 @@ annotations:
   # Links
   artifacthub.io/links: |
     - name: Documentation
-      url: https://github.com/phihos/haproxy-template-ingress-controller#readme
+      url: https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller#readme
     - name: Issue Tracker
-      url: https://github.com/phihos/haproxy-template-ingress-controller/issues
+      url: https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/issues
 
   # Recommendations
   artifacthub.io/recommendations: |

--- a/charts/haproxy-template-ic/README.md
+++ b/charts/haproxy-template-ic/README.md
@@ -49,7 +49,7 @@ helm install my-controller ./charts/haproxy-template-ic \
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `replicaCount` | Number of controller replicas (2+ recommended for HA) | `2` |
-| `image.repository` | Controller image repository | `ghcr.io/phihos/haproxy-template-ic` |
+| `image.repository` | Controller image repository | `ghcr.io/haproxy-template-ic/haproxy-template-ingress-controller` |
 | `image.tag` | Controller image tag | Chart appVersion |
 | `controller.templateLibraries.ingress.enabled` | Enable Ingress resource support | `true` |
 | `controller.templateLibraries.gateway.enabled` | Enable Gateway API support (HTTPRoute, GRPCRoute) | `false` |

--- a/charts/haproxy-template-ic/templates/NOTES.txt
+++ b/charts/haproxy-template-ic/templates/NOTES.txt
@@ -94,4 +94,4 @@ Next Steps:
   3. Create Ingress resources to configure routing
 
 For more information, visit:
-  https://github.com/phihos/haproxy-template-ingress-controller
+  https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller

--- a/charts/haproxy-template-ic/values.yaml
+++ b/charts/haproxy-template-ic/values.yaml
@@ -40,7 +40,7 @@ replicaCount: 2
 
 # Controller image configuration
 image:
-  repository: ghcr.io/phihos/haproxy-template-ic
+  repository: ghcr.io/haproxy-template-ic/haproxy-template-ingress-controller
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion
   tag: ""

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -196,7 +196,7 @@ Install the controller using Helm with default configuration:
 
 ```bash
 # Add the Helm repository (if published)
-# helm repo add haproxy-template-ic https://phihos.github.io/haproxy-template-ic
+# helm repo add haproxy-template-ic https://haproxy-template-ic.github.io/haproxy-template-ingress-controller
 # helm repo update
 
 # Install from local chart

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -818,4 +818,4 @@ See [Debugging Guide](./operations/debugging.md) for details.
 - [Configuration Reference](./configuration.md) - Complete configuration options
 - [High Availability Guide](./operations/high-availability.md) - HA-specific troubleshooting
 - [Debugging Guide](./operations/debugging.md) - Advanced debugging techniques
-- [GitHub Issues](https://github.com/phihos/haproxy-template-ingress-controller/issues) - Report bugs and request features
+- [GitHub Issues](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/issues) - Report bugs and request features


### PR DESCRIPTION
Migrate all URLs from the old personal repository to the new organization:

- GitHub repo: `github.com/phihos/haproxy-template-ingress-controller` to `github.com/HAProxy-Template-IC/haproxy-template-ingress-controller`
- Container registry: `ghcr.io/phihos/haproxy-template-ic` to `ghcr.io/haproxy-template-ic/haproxy-template-ingress-controller`
- Helm repo: `phihos.github.io/haproxy-template-ic` to `haproxy-template-ic.github.io/haproxy-template-ingress-controller`

Files updated:
- README.md (CI badge)
- NOTICE (attribution)
- docs/troubleshooting.md (GitHub Issues link)
- docs/getting-started.md (Helm repo URL)
- charts/haproxy-template-ic/values.yaml (image repository)
- charts/haproxy-template-ic/README.md (image repository docs)
- charts/haproxy-template-ic/Chart.yaml (home, sources, annotations)
- charts/haproxy-template-ic/templates/NOTES.txt (info link)