### PR TITLE
Optimize CI acceptance test image building with GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,14 @@ jobs:
           wait: 120s
           node_image: kindest/node:v1.32.0
 
+      # Login to GHCR to pull the pre-built image
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Pull and load controller image from GHCR
       - name: Load controller image into kind
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   GO_VERSION: '1.25'
-  CI_IMAGE: ghcr.io/${{ github.repository }}:ci-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   lint:
@@ -84,8 +83,17 @@ jobs:
 
   build-test-image:
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image-name.outputs.image }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Compute image name
+        id: image-name
+        run: |
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPO_LOWER}:ci-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -102,7 +110,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.CI_IMAGE }}
+          tags: ${{ steps.image-name.outputs.image }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -135,8 +143,8 @@ jobs:
       # Pull and load controller image from GHCR
       - name: Load controller image into kind
         run: |
-          docker pull ${{ env.CI_IMAGE }}
-          docker tag ${{ env.CI_IMAGE }} haproxy-template-ic:test
+          docker pull ${{ needs.build-test-image.outputs.image }}
+          docker tag ${{ needs.build-test-image.outputs.image }} haproxy-template-ic:test
           kind load docker-image haproxy-template-ic:test --name acceptance-${{ matrix.index }}
 
       # Install CRD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,7 @@ jobs:
       packages: write
     steps:
       - uses: jenskeiner/ghcr-container-repository-cleanup-action@v1
+        continue-on-error: true
         with:
           include-tags: '^ci-.*$'
           keep-n-tagged: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +16,7 @@ concurrency:
 
 env:
   GO_VERSION: '1.25'
+  CI_IMAGE: ghcr.io/${{ github.repository }}:ci-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   lint:
@@ -80,8 +82,36 @@ jobs:
           HAPROXY_VERSION: ${{ matrix.haproxy_version }}
           KEEP_CLUSTER: "false"
 
+  build-test-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.CI_IMAGE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_TAG=ci-${{ github.run_id }}
+
   test-acceptance:
     runs-on: ubuntu-latest
+    needs: [build-test-image]
     strategy:
       fail-fast: false
       matrix:
@@ -102,10 +132,11 @@ jobs:
           wait: 120s
           node_image: kindest/node:v1.32.0
 
-      # Build and load controller image
-      - name: Build and load controller image
+      # Pull and load controller image from GHCR
+      - name: Load controller image into kind
         run: |
-          docker build -t haproxy-template-ic:test .
+          docker pull ${{ env.CI_IMAGE }}
+          docker tag ${{ env.CI_IMAGE }} haproxy-template-ic:test
           kind load docker-image haproxy-template-ic:test --name acceptance-${{ matrix.index }}
 
       # Install CRD
@@ -232,3 +263,16 @@ jobs:
         run: |
           # Delete kind cluster
           kind delete cluster --name haproxy-template-ic-dev || true
+
+  cleanup-ci-images:
+    runs-on: ubuntu-latest
+    needs: [test-acceptance]
+    if: always()
+    permissions:
+      packages: write
+    steps:
+      - uses: jenskeiner/ghcr-container-repository-cleanup-action@v1
+        with:
+          include-tags: '^ci-.*$'
+          keep-n-tagged: 5
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The CI workflow has 4 acceptance test shards, each building the same Docker image from scratch (~2 min each), wasting ~8 minutes of compute time. This PR optimizes by building the image once and sharing it via GHCR.

- Add `build-test-image` job that builds and pushes to GHCR with BuildKit layer caching (`cache-from/to: type=gha`)
- Modify `test-acceptance` to depend on the build job and pull the pre-built image instead of building
- Add `cleanup-ci-images` job that removes old CI images, keeping the 5 most recent for debugging

## Test plan

- [ ] CI pipeline completes successfully with all acceptance tests passing
- [ ] Verify image is pushed to GHCR with `ci-*` tag
- [ ] Verify cleanup job runs and doesn't delete recent images