### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/controller/docs/configuration.md
+++ b/docs/controller/docs/configuration.md
@@ -951,7 +951,7 @@ detailed error messages.
 
 - [Template Syntax and Filters](./templating.md) - Detailed template documentation
 - [Supported HAProxy Configuration](./supported-configuration.md) - HAProxy sections and child components
-- [Helm Chart Values](../charts/haproxy-template-ic/values.yaml) - Production deployment examples
+- [Helm Chart Values](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/charts/haproxy-template-ic/values.yaml) - Production deployment examples
 
 ## Troubleshooting
 

--- a/docs/controller/docs/development/design.md
+++ b/docs/controller/docs/development/design.md
@@ -82,7 +82,7 @@ Pure business logic components (templating, k8s, dataplane) have no event depend
 - [Performance](../operations/performance.md) - Resource sizing and optimization
 
 ### Package Documentation
-- [Controller Package](../../pkg/controller/README.md) - Event-driven controller implementation
-- [Template Engine](../../pkg/templating/README.md) - Template engine API reference
-- [Kubernetes Integration](../../pkg/k8s/README.md) - Resource watching and indexing API
-- [Dataplane Integration](../../pkg/dataplane/README.md) - HAProxy configuration synchronization
+- [Controller Package](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/pkg/controller/README.md) - Event-driven controller implementation
+- [Template Engine](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/pkg/templating/README.md) - Template engine API reference
+- [Kubernetes Integration](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/pkg/k8s/README.md) - Resource watching and indexing API
+- [Dataplane Integration](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/pkg/dataplane/README.md) - HAProxy configuration synchronization

--- a/docs/controller/docs/getting-started.md
+++ b/docs/controller/docs/getting-started.md
@@ -524,4 +524,4 @@ kubectl delete crd haproxytemplateconfigs.haproxy-template-ic.github.io
 - [Templating Guide](./templating.md) - Template syntax and filters
 - [HAProxy Configuration](./supported-configuration.md) - Supported HAProxy features
 - [Watching Resources](./watching-resources.md) - Resource watching configuration
-- [Helm Chart Documentation](../charts/haproxy-template-ic/README.md) - Chart values and options
+- [Helm Chart Documentation](/helm-chart/latest/) - Chart values and options

--- a/docs/controller/docs/index.md
+++ b/docs/controller/docs/index.md
@@ -31,7 +31,7 @@ helm repo update
 helm install my-controller haproxy-template-ic/haproxy-template-ic
 ```
 
-See the [Helm Chart Installation Guide](helm-chart/index.md) for detailed configuration options.
+See the [Helm Chart Installation Guide](/helm-chart/latest/) for detailed configuration options.
 
 ### Create an Ingress
 
@@ -60,9 +60,9 @@ spec:
 | Section | Description |
 |---------|-------------|
 | [Getting Started](getting-started.md) | Initial setup and basic concepts |
-| [Helm Chart](helm-chart/index.md) | Installation via Helm with pre-built templates |
-| [Gateway API](helm-chart/gateway-api.md) | HTTPRoute and GRPCRoute support |
-| [HAProxy Annotations](helm-chart/annotations.md) | Compatible with haproxy.org annotations |
+| [Helm Chart](/helm-chart/latest/) | Installation via Helm with pre-built templates |
+| [Gateway API](/helm-chart/latest/gateway-api/) | HTTPRoute and GRPCRoute support |
+| [HAProxy Annotations](/helm-chart/latest/annotations/) | Compatible with haproxy.org annotations |
 | [Templating](templating.md) | Custom template development |
 | [Operations](operations/high-availability.md) | Production deployment guidance |
 

--- a/docs/controller/docs/templating.md
+++ b/docs/controller/docs/templating.md
@@ -1255,8 +1255,8 @@ haproxy_config:
 
 ## See Also
 
-- [Template Engine Reference](../pkg/templating/README.md) - Detailed templating API and error handling
+- [Template Engine Reference](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/pkg/templating/README.md) - Detailed templating API and error handling
 - [Configuration Reference](supported-configuration.md) - Complete configuration schema
 - [Gonja Documentation](https://github.com/nikolalohinski/gonja) - Full template syntax reference
-- [Helm Chart Values](../charts/haproxy-template-ic/values.yaml) - Production-ready template examples
+- [Helm Chart Values](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/charts/haproxy-template-ic/values.yaml) - Production-ready template examples
 - [HAProxy Configuration Manual](https://docs.haproxy.org/2.9/configuration.html) - HAProxy configuration reference

--- a/docs/controller/docs/watching-resources.md
+++ b/docs/controller/docs/watching-resources.md
@@ -1056,5 +1056,5 @@ See [Configuration Reference](./configuration.md) for additional configuration g
 
 - [Configuration Reference](./configuration.md) - Complete configuration syntax and field descriptions
 - [Templating Guide](./templating.md) - Template syntax and resource access patterns
-- [pkg/k8s README](../pkg/k8s/README.md) - Store implementation details and API documentation
+- [pkg/k8s README](https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/blob/main/pkg/k8s/README.md) - Store implementation details and API documentation
 - [Architecture Design](./development/design.md) - System architecture and component interactions


### PR DESCRIPTION
Replace relative links that pointed outside the docs directory with either absolute paths or GitHub URLs. This fixes MkDocs build warnings about missing link targets.

Link strategy:
- Cross-doc-set links (helm chart docs): Use absolute paths like `/helm-chart/latest/`
- Source code links (pkg/, charts/): Use GitHub URLs with `/blob/main/` path

Files modified:
- `docs/controller/docs/index.md` - 4 links to helm chart docs
- `docs/controller/docs/configuration.md` - 1 link to values.yaml
- `docs/controller/docs/getting-started.md` - 1 link to helm chart docs
- `docs/controller/docs/templating.md` - 2 links to pkg/ and charts/
- `docs/controller/docs/watching-resources.md` - 1 link to pkg/k8s
- `docs/controller/docs/development/design.md` - 4 links to pkg/ READMEs