### PR TITLE
Add path-based CI filtering, PR docs preview, and documentation styling fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   packages: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +19,41 @@ env:
   GO_VERSION: '1.25'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      helm: ${{ steps.filter.outputs.helm }}
+      docs: ${{ steps.filter.outputs.docs }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'Dockerfile'
+              - 'scripts/**'
+            helm:
+              - 'charts/**'
+              - '!charts/**/docs/**'
+              - '!charts/**/mkdocs.yml'
+            docs:
+              - 'docs/**'
+              - 'charts/**/docs/**'
+              - 'charts/**/mkdocs.yml'
+            ci:
+              - '.github/workflows/**'
+              - '.golangci.yml'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +64,8 @@ jobs:
       - run: make lint
 
   audit:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +76,8 @@ jobs:
       - run: make audit
 
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +93,8 @@ jobs:
       - run: make test
 
   test-integration:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -82,6 +123,8 @@ jobs:
           KEEP_CLUSTER: "false"
 
   build-test-image:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.image-name.outputs.image }}
@@ -118,8 +161,9 @@ jobs:
             GIT_TAG=ci-${{ github.run_id }}
 
   test-acceptance:
+    needs: [changes, build-test-image]
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
-    needs: [build-test-image]
     strategy:
       fail-fast: false
       matrix:
@@ -181,6 +225,8 @@ jobs:
           SKIP_PARALLEL_RUNNER: "true"
 
   validate-helm-libraries:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.helm == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -240,6 +286,8 @@ jobs:
           ./bin/controller validate -f /tmp/merged-config.yaml
 
   test-routes:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.helm == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -281,9 +329,9 @@ jobs:
           kind delete cluster --name haproxy-template-ic-dev || true
 
   cleanup-ci-images:
+    needs: [changes, test-acceptance]
+    if: always() && (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true')
     runs-on: ubuntu-latest
-    needs: [test-acceptance]
-    if: always()
     permissions:
       packages: write
     steps:
@@ -293,3 +341,38 @@ jobs:
           include-tags: '^ci-.*$'
           keep-n-tagged: 5
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  docs-preview:
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install mkdocs-material
+
+      - name: Copy shared CSS to stylesheets dirs
+        run: |
+          cp docs/shared/colors.css docs/controller/docs/stylesheets/
+          cp docs/shared/colors.css charts/haproxy-template-ic/docs/stylesheets/
+
+      - name: Build controller docs
+        run: |
+          cd docs/controller
+          mkdocs build -d ../../_site/controller
+
+      - name: Build helm chart docs
+        run: |
+          cd charts/haproxy-template-ic
+          mkdocs build -d ../../_site/helm-chart
+
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: _site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,27 @@ jobs:
           cd charts/haproxy-template-ic
           mkdocs build -d ../../_site/helm-chart
 
+      - name: Create PR preview landing page
+        run: |
+          cat > _site/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>PR Preview - HAProxy Template IC Docs</title>
+            <style>
+              body { font-family: system-ui; max-width: 600px; margin: 50px auto; padding: 20px; }
+              a { display: block; margin: 10px 0; padding: 15px; background: #f0f0f0; text-decoration: none; border-radius: 4px; }
+              a:hover { background: #e0e0e0; }
+            </style>
+          </head>
+          <body>
+            <h1>PR Preview</h1>
+            <a href="./controller/">Controller Documentation</a>
+            <a href="./helm-chart/">Helm Chart Documentation</a>
+          </body>
+          </html>
+          EOF
+
       - uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: _site/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,9 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
+    environment:
+      name: pr-preview
+      url: https://haproxy-template-ic.github.io/haproxy-template-ingress-controller/pr-preview/pr-${{ github.event.number }}/
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
         with:
           python-version: '3.x'
 
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mike
 
       - name: Copy shared CSS to stylesheets dirs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,41 +355,30 @@ jobs:
 
       - run: pip install mkdocs-material mike
 
+      - name: Fetch production site
+        run: |
+          git clone --depth 1 https://github.com/HAProxy-Template-IC/haproxy-template-ic.github.io.git _site
+          rm -rf _site/.git
+
       - name: Copy shared CSS to stylesheets dirs
         run: |
           cp docs/shared/colors.css docs/controller/docs/stylesheets/
           cp docs/shared/colors.css charts/haproxy-template-ic/docs/stylesheets/
 
-      - name: Build controller docs
+      - name: Build and overlay controller docs
         run: |
           cd docs/controller
-          mkdocs build -d ../../_site/controller
+          mkdocs build -d ../../_site/controller/dev
 
-      - name: Build helm chart docs
+      - name: Build and overlay helm chart docs
         run: |
           cd charts/haproxy-template-ic
-          mkdocs build -d ../../_site/helm-chart
+          mkdocs build -d ../../_site/helm-chart/dev
 
-      - name: Create PR preview landing page
+      - name: Update landing page and shared assets
         run: |
-          cat > _site/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>PR Preview - HAProxy Template IC Docs</title>
-            <style>
-              body { font-family: system-ui; max-width: 600px; margin: 50px auto; padding: 20px; }
-              a { display: block; margin: 10px 0; padding: 15px; background: #f0f0f0; text-decoration: none; border-radius: 4px; }
-              a:hover { background: #e0e0e0; }
-            </style>
-          </head>
-          <body>
-            <h1>PR Preview</h1>
-            <a href="./controller/">Controller Documentation</a>
-            <a href="./helm-chart/">Helm Chart Documentation</a>
-          </body>
-          </html>
-          EOF
+          cp docs/landing-page/index.html _site/index.html
+          cp docs/shared/colors.css _site/shared/colors.css
 
       - uses: rossjrw/pr-preview-action@v1
         with:

--- a/.github/workflows/docs-controller.yaml
+++ b/.github/workflows/docs-controller.yaml
@@ -29,6 +29,9 @@ jobs:
 
       - run: pip install mkdocs-material mike
 
+      - name: Copy shared CSS to stylesheets
+        run: cp docs/shared/colors.css docs/controller/docs/stylesheets/
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/docs-helm-chart.yaml
+++ b/.github/workflows/docs-helm-chart.yaml
@@ -29,6 +29,9 @@ jobs:
 
       - run: pip install mkdocs-material mike
 
+      - name: Copy shared CSS to stylesheets
+        run: cp docs/shared/colors.css charts/haproxy-template-ic/docs/stylesheets/
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ __debug_bin
 
 # Air (live reload) temporary files
 tmp/
+
+# Copied shared CSS files (source of truth is docs/shared/colors.css)
+docs/controller/docs/stylesheets/colors.css
+charts/haproxy-template-ic/docs/stylesheets/colors.css

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HAProxy Template I(ngress)C(ontroller)
 
 <p align="center">
-  <img src="docs/assets/logo.svg" alt="HAProxy Template IC Logo" width="400">
+  <img src="docs/controller/docs/assets/logo.svg" alt="HAProxy Template IC Logo" width="400">
 </p>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/charts/haproxy-template-ic/docs/assets/logo-icon.svg
+++ b/charts/haproxy-template-ic/docs/assets/logo-icon.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- HAProxy Template IC — simplified icon (auto light/dark adaptive SVG) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" role="img" aria-labelledby="title desc">
+  <title id="title">HAProxy Template IC icon (auto light/dark)</title>
+  <desc id="desc">Adaptive minimalist icon with templating tag "{%%}" in monospace font. Automatically switches color scheme between light and dark mode.</desc>
+
+  <style>
+    :root {
+      --brand: #0b3a66;  /* text color in light mode */
+      --bg: transparent; /* background color in light mode */
+    }
+    svg { background: var(--bg); }
+
+    /* Dark mode overrides */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --brand: #e8edf4; /* light text on dark bg */
+        --bg: #0b3a66;    /* dark background */
+      }
+    }
+
+    .icon-text {
+      fill: var(--brand);
+      font-family: "JetBrains Mono", "Fira Code", "Courier New", monospace;
+      font-weight: 700;
+      letter-spacing: 6px;
+    }
+  </style>
+
+  <!-- Symbol -->
+  <text class="icon-text" x="250" y="190" text-anchor="middle" font-size="140">
+    {%%}
+  </text>
+</svg>

--- a/charts/haproxy-template-ic/docs/assets/logo-icon.svg
+++ b/charts/haproxy-template-ic/docs/assets/logo-icon.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- HAProxy Template IC — simplified icon (auto light/dark adaptive SVG) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 380 160" width="380" height="160" role="img" aria-labelledby="title desc">
   <title id="title">HAProxy Template IC icon (auto light/dark)</title>
   <desc id="desc">Adaptive minimalist icon with templating tag "{%%}" in monospace font. Automatically switches color scheme between light and dark mode.</desc>
 
@@ -28,7 +28,7 @@
   </style>
 
   <!-- Symbol -->
-  <text class="icon-text" x="250" y="190" text-anchor="middle" font-size="140">
+  <text class="icon-text" x="190" y="120" text-anchor="middle" font-size="140">
     {%%}
   </text>
 </svg>

--- a/charts/haproxy-template-ic/docs/stylesheets/extra.css
+++ b/charts/haproxy-template-ic/docs/stylesheets/extra.css
@@ -2,14 +2,16 @@
 @import url('./colors.css');
 
 /* Map brand colors to MkDocs Material variables */
+/* Light mode: light blue header */
 :root {
-  --md-primary-fg-color: var(--brand-header);
+  --md-primary-fg-color: #4a8bc2;
   --md-primary-fg-color--light: var(--brand-primary-light);
   --md-primary-fg-color--dark: var(--brand-primary-dark);
 }
 
-/* Dark mode: use lighter color for links */
+/* Dark mode: dark blue header to match logo, lighter links */
 [data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #0b3a66;
   --md-typeset-a-color: var(--brand-primary-light);
 }
 

--- a/charts/haproxy-template-ic/docs/stylesheets/extra.css
+++ b/charts/haproxy-template-ic/docs/stylesheets/extra.css
@@ -3,7 +3,7 @@
 
 /* Map brand colors to MkDocs Material variables */
 /* Light mode: light blue header */
-:root {
+[data-md-color-scheme="default"] {
   --md-primary-fg-color: #4a8bc2;
   --md-primary-fg-color--light: var(--brand-primary-light);
   --md-primary-fg-color--dark: var(--brand-primary-dark);

--- a/charts/haproxy-template-ic/docs/stylesheets/extra.css
+++ b/charts/haproxy-template-ic/docs/stylesheets/extra.css
@@ -3,7 +3,7 @@
 
 /* Map brand colors to MkDocs Material variables */
 :root {
-  --md-primary-fg-color: var(--brand-primary);
+  --md-primary-fg-color: var(--brand-header);
   --md-primary-fg-color--light: var(--brand-primary-light);
   --md-primary-fg-color--dark: var(--brand-primary-dark);
 }

--- a/charts/haproxy-template-ic/docs/stylesheets/extra.css
+++ b/charts/haproxy-template-ic/docs/stylesheets/extra.css
@@ -1,5 +1,5 @@
-/* Import shared brand colors */
-@import url('/shared/colors.css');
+/* Import shared brand colors (copied during build from docs/shared/colors.css) */
+@import url('./colors.css');
 
 /* Map brand colors to MkDocs Material variables */
 :root {

--- a/charts/haproxy-template-ic/mkdocs.yml
+++ b/charts/haproxy-template-ic/mkdocs.yml
@@ -58,7 +58,7 @@ extra:
     provider: mike
   alternate:
     - name: Controller Docs
-      link: /controller/latest/
+      link: https://haproxy-template-ic.github.io/controller/latest/
       lang: controller
   social:
     - icon: fontawesome/brands/github

--- a/charts/haproxy-template-ic/mkdocs.yml
+++ b/charts/haproxy-template-ic/mkdocs.yml
@@ -9,8 +9,8 @@ docs_dir: docs
 
 theme:
   name: material
-  logo: assets/logo.svg
-  favicon: assets/logo.svg
+  logo: assets/logo-icon.svg
+  favicon: assets/logo-icon.svg
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/docs/controller/docs/assets/logo-icon.svg
+++ b/docs/controller/docs/assets/logo-icon.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- HAProxy Template IC — simplified icon (auto light/dark adaptive SVG) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" role="img" aria-labelledby="title desc">
+  <title id="title">HAProxy Template IC icon (auto light/dark)</title>
+  <desc id="desc">Adaptive minimalist icon with templating tag "{%%}" in monospace font. Automatically switches color scheme between light and dark mode.</desc>
+
+  <style>
+    :root {
+      --brand: #0b3a66;  /* text color in light mode */
+      --bg: transparent; /* background color in light mode */
+    }
+    svg { background: var(--bg); }
+
+    /* Dark mode overrides */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --brand: #e8edf4; /* light text on dark bg */
+        --bg: #0b3a66;    /* dark background */
+      }
+    }
+
+    .icon-text {
+      fill: var(--brand);
+      font-family: "JetBrains Mono", "Fira Code", "Courier New", monospace;
+      font-weight: 700;
+      letter-spacing: 6px;
+    }
+  </style>
+
+  <!-- Symbol -->
+  <text class="icon-text" x="250" y="190" text-anchor="middle" font-size="140">
+    {%%}
+  </text>
+</svg>

--- a/docs/controller/docs/assets/logo-icon.svg
+++ b/docs/controller/docs/assets/logo-icon.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- HAProxy Template IC — simplified icon (auto light/dark adaptive SVG) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 300" width="500" height="300" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 380 160" width="380" height="160" role="img" aria-labelledby="title desc">
   <title id="title">HAProxy Template IC icon (auto light/dark)</title>
   <desc id="desc">Adaptive minimalist icon with templating tag "{%%}" in monospace font. Automatically switches color scheme between light and dark mode.</desc>
 
@@ -28,7 +28,7 @@
   </style>
 
   <!-- Symbol -->
-  <text class="icon-text" x="250" y="190" text-anchor="middle" font-size="140">
+  <text class="icon-text" x="190" y="120" text-anchor="middle" font-size="140">
     {%%}
   </text>
 </svg>

--- a/docs/controller/docs/stylesheets/extra.css
+++ b/docs/controller/docs/stylesheets/extra.css
@@ -2,14 +2,16 @@
 @import url('./colors.css');
 
 /* Map brand colors to MkDocs Material variables */
+/* Light mode: light blue header */
 :root {
-  --md-primary-fg-color: var(--brand-header);
+  --md-primary-fg-color: #4a8bc2;
   --md-primary-fg-color--light: var(--brand-primary-light);
   --md-primary-fg-color--dark: var(--brand-primary-dark);
 }
 
-/* Dark mode: use lighter color for links */
+/* Dark mode: dark blue header to match logo, lighter links */
 [data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #0b3a66;
   --md-typeset-a-color: var(--brand-primary-light);
 }
 

--- a/docs/controller/docs/stylesheets/extra.css
+++ b/docs/controller/docs/stylesheets/extra.css
@@ -3,7 +3,7 @@
 
 /* Map brand colors to MkDocs Material variables */
 /* Light mode: light blue header */
-:root {
+[data-md-color-scheme="default"] {
   --md-primary-fg-color: #4a8bc2;
   --md-primary-fg-color--light: var(--brand-primary-light);
   --md-primary-fg-color--dark: var(--brand-primary-dark);

--- a/docs/controller/docs/stylesheets/extra.css
+++ b/docs/controller/docs/stylesheets/extra.css
@@ -3,7 +3,7 @@
 
 /* Map brand colors to MkDocs Material variables */
 :root {
-  --md-primary-fg-color: var(--brand-primary);
+  --md-primary-fg-color: var(--brand-header);
   --md-primary-fg-color--light: var(--brand-primary-light);
   --md-primary-fg-color--dark: var(--brand-primary-dark);
 }

--- a/docs/controller/docs/stylesheets/extra.css
+++ b/docs/controller/docs/stylesheets/extra.css
@@ -1,5 +1,5 @@
-/* Import shared brand colors */
-@import url('/shared/colors.css');
+/* Import shared brand colors (copied during build from docs/shared/colors.css) */
+@import url('./colors.css');
 
 /* Map brand colors to MkDocs Material variables */
 :root {

--- a/docs/controller/mkdocs.yml
+++ b/docs/controller/mkdocs.yml
@@ -9,8 +9,8 @@ docs_dir: docs
 
 theme:
   name: material
-  logo: assets/logo.svg
-  favicon: assets/logo.svg
+  logo: assets/logo-icon.svg
+  favicon: assets/logo-icon.svg
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/docs/controller/mkdocs.yml
+++ b/docs/controller/mkdocs.yml
@@ -93,7 +93,7 @@ extra:
     provider: mike
   alternate:
     - name: Helm Chart Docs
-      link: /helm-chart/latest/
+      link: https://haproxy-template-ic.github.io/helm-chart/latest/
       lang: helm
   social:
     - icon: fontawesome/brands/github

--- a/docs/landing-page/index.html
+++ b/docs/landing-page/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>HAProxy Template IC Documentation</title>
-  <link rel="stylesheet" href="/shared/colors.css">
+  <link rel="stylesheet" href="./shared/colors.css">
   <style>
     * { box-sizing: border-box; }
     body {
@@ -68,7 +68,7 @@
     <div class="doc-card">
       <h2>Controller Documentation</h2>
       <p>Architecture, configuration, templating, operations, and development guides.</p>
-      <p><a href="/controller/latest/">View latest documentation</a></p>
+      <p><a href="./controller/latest/">View latest documentation</a></p>
       <div class="versions">
         <h3>Available versions</h3>
         <div id="controller-versions" class="version-list">Loading...</div>
@@ -78,7 +78,7 @@
     <div class="doc-card">
       <h2>Helm Chart Documentation</h2>
       <p>Installation guide, Gateway API support, HAProxy annotations reference.</p>
-      <p><a href="/helm-chart/latest/">View latest documentation</a></p>
+      <p><a href="./helm-chart/latest/">View latest documentation</a></p>
       <div class="versions">
         <h3>Available versions</h3>
         <div id="helm-versions" class="version-list">Loading...</div>
@@ -89,14 +89,14 @@
   <script>
     async function loadVersions(prefix, elementId) {
       try {
-        const res = await fetch(`/${prefix}/versions.json`);
+        const res = await fetch(`./${prefix}/versions.json`);
         if (!res.ok) throw new Error('Not found');
         const versions = await res.json();
         const el = document.getElementById(elementId);
         el.innerHTML = versions.map(v => {
           const isAlias = v.aliases && v.aliases.length > 0;
           const label = isAlias ? `${v.version} (${v.aliases.join(', ')})` : v.version;
-          return `<a href="/${prefix}/${v.version}/" class="version-badge${isAlias ? ' alias' : ''}">${label}</a>`;
+          return `<a href="./${prefix}/${v.version}/" class="version-badge${isAlias ? ' alias' : ''}">${label}</a>`;
         }).join('');
       } catch (e) {
         document.getElementById(elementId).innerHTML = '<span style="color:#888">No versions published yet</span>';

--- a/docs/landing-page/index.html
+++ b/docs/landing-page/index.html
@@ -32,7 +32,7 @@
     .versions { margin-top: 16px; }
     .versions h3 { font-size: 0.9em; color: var(--brand-text-muted); margin-bottom: 8px; }
     .version-list { display: flex; flex-wrap: wrap; gap: 8px; }
-    .version-badge {
+    .doc-card a.version-badge {
       display: inline-block;
       padding: 4px 12px;
       background: var(--brand-primary);
@@ -41,7 +41,7 @@
       text-decoration: none;
       font-size: 0.85em;
     }
-    .version-badge:hover { background: var(--brand-primary-light); }
+    .doc-card a.version-badge:hover { background: var(--brand-primary-light); }
     .quick-start {
       background: var(--brand-border);
       border-radius: 6px;

--- a/docs/landing-page/index.html
+++ b/docs/landing-page/index.html
@@ -42,7 +42,6 @@
       font-size: 0.85em;
     }
     .version-badge:hover { background: var(--brand-primary-light); }
-    .version-badge.alias { background: var(--brand-primary-light); }
     .quick-start {
       background: var(--brand-border);
       border-radius: 6px;

--- a/docs/shared/colors.css
+++ b/docs/shared/colors.css
@@ -5,7 +5,7 @@
   --brand-primary: #0b3a66;
   --brand-primary-light: #1a5a96;
   --brand-primary-dark: #062744;
-  --brand-header: #0b3a66;
+  --brand-header: #4a8bc2;
   --brand-bg: #ffffff;
   --brand-text: #333;
   --brand-text-muted: #666;

--- a/docs/shared/colors.css
+++ b/docs/shared/colors.css
@@ -5,6 +5,7 @@
   --brand-primary: #0b3a66;
   --brand-primary-light: #1a5a96;
   --brand-primary-dark: #062744;
+  --brand-header: #0b3a66;
   --brand-bg: #ffffff;
   --brand-text: #333;
   --brand-text-muted: #666;
@@ -15,6 +16,7 @@
   :root {
     --brand-primary: #4a8bc2;
     --brand-primary-light: #6ba3d6;
+    --brand-header: #0b3a66;
     --brand-bg: #1e1e1e;
     --brand-text: #e8edf4;
     --brand-text-muted: #999;


### PR DESCRIPTION
## Summary

- Add path-based filtering to CI workflow to skip unnecessary jobs when only docs or charts change
- Add PR documentation preview workflow for reviewing docs changes before merge
- Fix documentation styling to properly follow light/dark theme preferences
- Add simplified logo icon for docs header with better visibility at small sizes
- Fix broken README logo path

## Changes

**CI Workflow:**
- Add path filtering to skip Go-related jobs when only docs/charts change

**Documentation:**
- Add PR preview workflow that deploys docs to `/pr-preview/pr-<number>/`
- Fix header color to follow website theme preference (not OS preference)
- Add simplified `{%%}` logo icon for docs header (full logo too small to read)
- Fix README logo path from `docs/assets/logo.svg` to correct location

**Styling:**
- Light mode: light blue header, dark blue text
- Dark mode: dark blue header, light text