### PR TITLE
Fix docs deployment race condition with concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
 
   docs-preview:
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.docs == 'true'
+    if: github.event_name == 'pull_request' && (needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true')
     runs-on: ubuntu-latest
     environment:
       name: pr-preview

--- a/.github/workflows/docs-controller.yaml
+++ b/.github/workflows/docs-controller.yaml
@@ -14,6 +14,10 @@ on:
         description: 'Controller version (e.g., 0.2.0)'
         required: false
 
+concurrency:
+  group: docs-deployment
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-helm-chart.yaml
+++ b/.github/workflows/docs-helm-chart.yaml
@@ -14,6 +14,10 @@ on:
         description: 'Chart version (e.g., 0.3.0)'
         required: false
 
+concurrency:
+  group: docs-deployment
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When both controller and helm chart docs are modified in the same commit, both `docs-controller.yaml` and `docs-helm-chart.yaml` workflows run concurrently and push to the same GitHub Pages repository. The second push fails with "remote contains work that you do not have locally".

This adds a shared `concurrency` group (`docs-deployment`) to both workflows with `cancel-in-progress: false`, so when both trigger simultaneously, one queues until the other completes.

Also makes `docs-preview` run when CI files change, matching other jobs.

Fixes the failure in https://github.com/HAProxy-Template-IC/haproxy-template-ingress-controller/actions/runs/19833506344