### PR TITLE
Reduce integration test flakiness with retry mechanisms and CI optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,13 @@ jobs:
       - run: make test
 
   test-integration:
-    needs: changes
+    needs: [changes, lint, audit, test]
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         haproxy_version: ['3.0', '3.1', '3.2']
         total: [4]
@@ -117,7 +119,11 @@ jobs:
           packages: ./tests/integration
           flags: "-tags=integration"
       - name: Run integration tests (shard ${{ matrix.index }}/${{ matrix.total }})
-        run: TEST_RUN_PATTERN="${{ steps.test-split.outputs.run }}" make test-integration
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          command: TEST_RUN_PATTERN="${{ steps.test-split.outputs.run }}" make test-integration
         env:
           HAPROXY_VERSION: ${{ matrix.haproxy_version }}
           KEEP_CLUSTER: "false"
@@ -164,8 +170,10 @@ jobs:
     needs: [changes, build-test-image]
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         total: [4]
         index: [0, 1, 2, 3]
@@ -216,10 +224,14 @@ jobs:
 
       # Run tests sequentially (no -parallel flag to avoid resource contention)
       - name: Run acceptance tests (shard ${{ matrix.index }})
-        run: |
-          go test -tags=acceptance -v -timeout 15m \
-            -run "${{ steps.test-split.outputs.run }}" \
-            ./tests/acceptance/...
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 18
+          max_attempts: 2
+          command: |
+            go test -tags=acceptance -v -timeout 15m \
+              -run "${{ steps.test-split.outputs.run }}" \
+              ./tests/acceptance/...
         env:
           # Skip parallel test runner - we run individual tests via sharding
           SKIP_PARALLEL_RUNNER: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,11 +298,13 @@ jobs:
           ./bin/controller validate -f /tmp/merged-config.yaml
 
   test-routes:
-    needs: changes
+    needs: [changes, lint, audit, test]
     if: needs.changes.outputs.code == 'true' || needs.changes.outputs.helm == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         haproxy_version: ['3.0', '3.1', '3.2']
     name: test-routes (HAProxy ${{ matrix.haproxy_version }})
@@ -322,17 +324,18 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Start dev environment
-        run: |
-          # Start dev environment (creates cluster, builds image, deploys controller)
-          HAPROXY_VERSION=${{ matrix.haproxy_version }} ./scripts/start-dev-env.sh
+      - name: Start dev environment and run route tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          command: |
+            # Start dev environment (creates cluster, builds image, deploys controller)
+            HAPROXY_VERSION=${{ matrix.haproxy_version }} ./scripts/start-dev-env.sh --timeout 240
+            # Test all ingress and HTTPRoute resources
+            ./scripts/test-routes.sh
         env:
           HAPROXY_VERSION: ${{ matrix.haproxy_version }}
-
-      - name: Run route tests
-        run: |
-          # Test all ingress and HTTPRoute resources
-          ./scripts/test-routes.sh
 
       - name: Cleanup
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ test-integration: ## Run integration tests (requires kind cluster)
 	@echo "  TEST_RUN_PATTERN   - Run specific tests matching pattern"
 ifdef TEST_RUN_PATTERN
 	@echo "Running tests matching pattern: $(TEST_RUN_PATTERN)"
-	$(GO) test -tags=integration -v -race -timeout 10m -run "$(TEST_RUN_PATTERN)" ./tests/integration
+	$(GO) test -tags=integration -v -race -timeout 15m -run "$(TEST_RUN_PATTERN)" ./tests/integration
 else
-	$(GO) test -tags=integration -v -race -timeout 10m ./tests/integration/...
+	$(GO) test -tags=integration -v -race -timeout 15m ./tests/integration/...
 endif
 
 test-acceptance: docker-build-test ## Run acceptance tests (builds image, creates kind cluster)

--- a/tests/integration/kind_cluster.go
+++ b/tests/integration/kind_cluster.go
@@ -204,12 +204,9 @@ func (k *KindCluster) CreateNamespace(name string) (*Namespace, error) {
 // CleanupOldTestNamespacesAsync triggers asynchronous cleanup of old test namespaces.
 // This function returns immediately without blocking - cleanup happens in the background.
 // It lists all namespaces with the "test-" prefix that are older than 5 minutes and deletes them.
-// This prevents race conditions where newly created test namespaces get deleted while tests are running.
+// The 5-minute age threshold ensures newly created test namespaces are not affected.
 func (k *KindCluster) CleanupOldTestNamespacesAsync() {
 	go func() {
-		// Wait a bit before starting cleanup to allow current tests to create their namespaces
-		time.Sleep(2 * time.Second)
-
 		ctx := context.Background()
 
 		// List all namespaces with test- prefix

--- a/tests/integration/wait.go
+++ b/tests/integration/wait.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// WaitConfig configures wait behavior with exponential backoff.
+type WaitConfig struct {
+	// InitialInterval is the starting interval between retry attempts.
+	InitialInterval time.Duration
+
+	// MaxInterval is the maximum interval between retry attempts.
+	// The backoff will not exceed this value.
+	MaxInterval time.Duration
+
+	// Timeout is the total time allowed for the wait operation.
+	Timeout time.Duration
+
+	// Multiplier is applied to the interval after each attempt.
+	// For example, 2.0 doubles the interval each time.
+	Multiplier float64
+}
+
+// DefaultWaitConfig provides sensible defaults for wait operations.
+func DefaultWaitConfig() WaitConfig {
+	return WaitConfig{
+		InitialInterval: 100 * time.Millisecond,
+		MaxInterval:     5 * time.Second,
+		Timeout:         5 * time.Minute,
+		Multiplier:      2.0,
+	}
+}
+
+// WaitForCondition polls with exponential backoff until the condition returns true
+// or the timeout is exceeded. The condition function should return (true, nil) when
+// the condition is satisfied, (false, nil) to continue waiting, or (false, error)
+// to record the last error (but continue waiting).
+//
+// The function checks the condition immediately before waiting, so if the condition
+// is already satisfied, it returns without delay.
+func WaitForCondition(ctx context.Context, cfg WaitConfig, condition func(context.Context) (bool, error)) error {
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	interval := cfg.InitialInterval
+	var lastErr error
+
+	// Check immediately before first wait
+	if done, err := condition(ctx); done {
+		return nil
+	} else if err != nil {
+		lastErr = err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("timeout waiting for condition (last error: %w)", lastErr)
+			}
+			return fmt.Errorf("timeout waiting for condition: %w", ctx.Err())
+
+		case <-time.After(interval):
+			done, err := condition(ctx)
+			if done {
+				return nil
+			}
+			if err != nil {
+				lastErr = err
+			}
+
+			// Exponential backoff
+			interval = time.Duration(float64(interval) * cfg.Multiplier)
+			if interval > cfg.MaxInterval {
+				interval = cfg.MaxInterval
+			}
+		}
+	}
+}
+
+// WaitForConditionWithProgress is like WaitForCondition but calls a progress
+// callback on each retry attempt. This is useful for logging progress during
+// long waits.
+func WaitForConditionWithProgress(
+	ctx context.Context,
+	cfg WaitConfig,
+	condition func(context.Context) (bool, error),
+	onProgress func(attempt int, elapsed time.Duration, lastErr error),
+) error {
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	interval := cfg.InitialInterval
+	var lastErr error
+	attempt := 0
+	start := time.Now()
+
+	// Check immediately before first wait
+	attempt++
+	if done, err := condition(ctx); done {
+		return nil
+	} else if err != nil {
+		lastErr = err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("timeout waiting for condition after %d attempts (last error: %w)", attempt, lastErr)
+			}
+			return fmt.Errorf("timeout waiting for condition after %d attempts: %w", attempt, ctx.Err())
+
+		case <-time.After(interval):
+			attempt++
+			done, err := condition(ctx)
+			if done {
+				return nil
+			}
+			if err != nil {
+				lastErr = err
+			}
+
+			if onProgress != nil {
+				onProgress(attempt, time.Since(start), lastErr)
+			}
+
+			// Exponential backoff
+			interval = time.Duration(float64(interval) * cfg.Multiplier)
+			if interval > cfg.MaxInterval {
+				interval = cfg.MaxInterval
+			}
+		}
+	}
+}


### PR DESCRIPTION
Addresses transient CI failures where HAProxy pod init containers get stuck or Dataplane API isn't ready when tests start.

**Infrastructure changes:**
- New `wait.go` utility with exponential backoff for reusable wait operations
- `waitForDataplaneAPI()` validates API is actually responding after port forwarding (not just that port-forward started)
- Increased port forwarding timeout from 10s to 30s
- Retry logic (3 attempts with backoff) for `TestDataplaneClient` and `TestDataplaneHighLevelClient` fixtures
- Removed unnecessary 2-second sleep from namespace cleanup (5-minute age threshold provides sufficient protection)
- Increased Go test timeout from 10m to 15m

**CI workflow improvements:**
- `max-parallel: 4` for integration tests (reduces from 12 to 4 concurrent jobs)
- `max-parallel: 2` for acceptance tests (reduces Kind cluster resource contention)
- `nick-fields/retry@v3` with 2 attempts for both integration and acceptance test steps
- Job dependencies (`needs: [lint, audit, test]`) to fail fast on quick checks
- Job-level timeouts (20m integration, 25m acceptance)