### PR TITLE
fix: restore and update GitHub Actions CI workflows

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,0 +1,31 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/haptic/**'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Publish Helm chart
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.PAGES_REPO_TOKEN }}
+          charts_dir: charts
+          charts_url: https://haproxy-template-ic.github.io/charts
+          owner: HAProxy-Template-IC
+          repository: haproxy-template-ic.github.io
+          branch: main
+          target_dir: charts
+          linting: "on"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,8 +380,9 @@ jobs:
 
       - name: Fetch production site
         run: |
-          git clone --depth 1 https://github.com/HAProxy-Template-IC/haproxy-template-ic.github.io.git _site
-          rm -rf _site/.git
+          git clone --depth 1 https://github.com/HAProxy-Template-IC/haproxy-template-ic.github.io.git _site \
+            && rm -rf _site/.git \
+            || mkdir -p _site/shared
 
       - name: Copy shared CSS to stylesheets dirs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,408 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.26'
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      helm: ${{ steps.filter.outputs.helm }}
+      docs: ${{ steps.filter.outputs.docs }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'Dockerfile'
+              - 'scripts/**'
+            helm:
+              - 'charts/**'
+              - '!charts/**/docs/**'
+              - '!charts/**/mkdocs.yml'
+            docs:
+              - 'docs/**'
+              - 'charts/**/docs/**'
+              - 'charts/**/mkdocs.yml'
+            ci:
+              - '.github/workflows/**'
+              - '.golangci.yml'
+
+  lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - run: make lint
+
+  audit:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - run: make audit
+
+  test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Install HAProxy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y haproxy
+          haproxy -v
+      - run: make test
+
+  test-integration:
+    needs: [changes, lint, audit, test]
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        haproxy_version: ['3.0', '3.1', '3.2']
+        total: [4]
+        index: [0, 1, 2, 3]
+    name: test-integration (HAProxy ${{ matrix.haproxy_version }}, shard ${{ matrix.index }}/${{ matrix.total }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: hashicorp-forge/go-test-split-action@v1
+        id: test-split
+        with:
+          index: ${{ matrix.index }}
+          total: ${{ matrix.total }}
+          packages: ./tests/integration
+          flags: "-tags=integration"
+      - name: Run integration tests (shard ${{ matrix.index }}/${{ matrix.total }})
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          command: TEST_RUN_PATTERN="${{ steps.test-split.outputs.run }}" make test-integration
+        env:
+          HAPROXY_VERSION: ${{ matrix.haproxy_version }}
+          KEEP_CLUSTER: "false"
+
+  build-test-image:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image-name.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image name
+        id: image-name
+        run: |
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPO_LOWER}:ci-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.image-name.outputs.image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_TAG=ci-${{ github.run_id }}
+
+  test-acceptance:
+    needs: [changes, build-test-image]
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        total: [4]
+        index: [0, 1, 2, 3]
+    name: test-acceptance (shard ${{ matrix.index }}/${{ matrix.total }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # Use helm/kind-action for optimized cluster setup
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: acceptance-${{ matrix.index }}
+          wait: 120s
+          node_image: kindest/node:v1.32.0
+
+      # Login to GHCR to pull the pre-built image
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pull and load controller image from GHCR
+      - name: Load controller image into kind
+        run: |
+          docker pull ${{ needs.build-test-image.outputs.image }}
+          docker tag ${{ needs.build-test-image.outputs.image }} haptic:test
+          kind load docker-image haptic:test --name acceptance-${{ matrix.index }}
+
+      # Install all CRDs
+      - name: Install CRDs
+        run: |
+          kubectl apply -f charts/haptic/crds/
+          kubectl wait --for=condition=Established crd/haproxytemplateconfigs.haproxy-haptic.org --timeout=60s
+          kubectl wait --for=condition=Established crd/haproxycfgs.haproxy-haptic.org --timeout=60s
+          kubectl wait --for=condition=Established crd/haproxymapfiles.haproxy-haptic.org --timeout=60s
+
+      # Determine which tests this shard runs (exclude TestAllAcceptanceParallel)
+      - uses: hashicorp-forge/go-test-split-action@v1
+        id: test-split
+        with:
+          index: ${{ matrix.index }}
+          total: ${{ matrix.total }}
+          packages: ./tests/acceptance
+          flags: "-tags=acceptance"
+
+      # Run tests sequentially (no -parallel flag to avoid resource contention)
+      - name: Run acceptance tests (shard ${{ matrix.index }})
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 18
+          max_attempts: 2
+          command: |
+            go test -tags=acceptance -v -timeout 15m \
+              -run "${{ steps.test-split.outputs.run }}" \
+              ./tests/acceptance/...
+        env:
+          # Skip parallel test runner - we run individual tests via sharding
+          SKIP_PARALLEL_RUNNER: "true"
+
+  validate-helm-libraries:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.helm == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        haproxy_version: ['3.0', '3.1', '3.2']
+    name: validate-helm-libraries (HAProxy ${{ matrix.haproxy_version }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install HAProxy ${{ matrix.haproxy_version }} from Vincent Bernat PPA
+        run: |
+          # Install PPA tools
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y software-properties-common
+
+          # Add HAProxy version-specific PPA
+          sudo add-apt-repository -y ppa:vbernat/haproxy-${{ matrix.haproxy_version }}
+
+          # Install specific HAProxy version
+          sudo apt-get update
+          sudo apt-get install -y haproxy=${{ matrix.haproxy_version }}.*
+
+          # Verify installation
+          haproxy -v
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Build controller binary
+        run: make build
+
+      - name: Render and validate Helm chart with all libraries
+        run: |
+          # Render chart with all libraries enabled
+          helm template charts/haptic \
+            --api-versions=gateway.networking.k8s.io/v1/GatewayClass \
+            --set controller.templateLibraries.ingress.enabled=true \
+            --set controller.templateLibraries.gateway.enabled=true \
+            --set controller.templateLibraries.haproxytech.enabled=true \
+            | yq 'select(.kind == "HAProxyTemplateConfig")' \
+            > /tmp/merged-config.yaml
+
+          # Validate the merged configuration
+          ./bin/haptic-controller validate -f /tmp/merged-config.yaml
+
+  test-routes:
+    needs: [changes, lint, audit, test]
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.helm == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        haproxy_version: ['3.0', '3.1', '3.2']
+    name: test-routes (HAProxy ${{ matrix.haproxy_version }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kind
+        run: |
+          # Install kind for creating local Kubernetes cluster
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Start dev environment and run route tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          command: |
+            # Start dev environment (creates cluster, builds image, deploys controller)
+            HAPROXY_VERSION=${{ matrix.haproxy_version }} ./scripts/start-dev-env.sh --timeout 240
+            # Test all ingress and HTTPRoute resources
+            ./scripts/test-routes.sh
+        env:
+          HAPROXY_VERSION: ${{ matrix.haproxy_version }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          # Delete kind cluster
+          kind delete cluster --name haptic-dev || true
+
+  cleanup-ci-images:
+    needs: [changes, test-acceptance]
+    if: always() && (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: jenskeiner/ghcr-container-repository-cleanup-action@v1
+        continue-on-error: true
+        with:
+          include-tags: '^ci-.*$'
+          keep-n-tagged: 5
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  docs-preview:
+    needs: changes
+    if: github.event_name == 'pull_request' && (needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true')
+    runs-on: ubuntu-latest
+    environment:
+      name: pr-preview
+      url: https://haproxy-template-ic.github.io/haproxy-template-ingress-controller/pr-preview/pr-${{ github.event.number }}/
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install mkdocs-material mike
+
+      - name: Fetch production site
+        run: |
+          git clone --depth 1 https://github.com/HAProxy-Template-IC/haproxy-template-ic.github.io.git _site
+          rm -rf _site/.git
+
+      - name: Copy shared CSS to stylesheets dirs
+        run: |
+          cp docs/shared/colors.css docs/controller/docs/stylesheets/
+          cp docs/shared/colors.css charts/haptic/docs/stylesheets/
+
+      - name: Build and overlay controller docs
+        run: |
+          cd docs/controller
+          mkdocs build -d ../../_site/controller/dev
+
+      - name: Build and overlay helm chart docs
+        run: |
+          cd charts/haptic
+          mkdocs build -d ../../_site/helm-chart/dev
+
+      - name: Update landing page and shared assets
+        run: |
+          cp docs/landing-page/index.html _site/index.html
+          cp docs/shared/colors.css _site/shared/colors.css
+
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: _site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Install lint tools
+        run: npm install -g markdownlint-cli2
       - run: make lint
 
   audit:
@@ -363,6 +365,7 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request' && (needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true')
     runs-on: ubuntu-latest
+    continue-on-error: true
     environment:
       name: pr-preview
       url: https://haproxy-template-ic.github.io/haproxy-template-ingress-controller/pr-preview/pr-${{ github.event.number }}/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,16 @@ jobs:
       - name: Copy shared CSS to stylesheets dirs
         run: |
           cp docs/shared/colors.css docs/controller/docs/stylesheets/
+          cp docs/shared/colors.css docs/landing/docs/stylesheets/
           cp docs/shared/colors.css charts/haptic/docs/stylesheets/
+
+      - name: Build and overlay landing page
+        run: |
+          cd docs/landing
+          LANDING_TEMP=$(mktemp -d)
+          mkdocs build -d "$LANDING_TEMP"
+          cp -a "$LANDING_TEMP"/* ../../_site/
+          rm -rf "$LANDING_TEMP"
 
       - name: Build and overlay controller docs
         run: |
@@ -399,9 +408,9 @@ jobs:
           cd charts/haptic
           mkdocs build -d ../../_site/helm-chart/dev
 
-      - name: Update landing page and shared assets
+      - name: Copy shared assets
         run: |
-          cp docs/landing-page/index.html _site/index.html
+          mkdir -p _site/shared
           cp docs/shared/colors.css _site/shared/colors.css
 
       - uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/docs-controller.yaml
+++ b/.github/workflows/docs-controller.yaml
@@ -1,0 +1,105 @@
+name: Deploy Controller Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/controller/**'
+      - 'docs/landing-page/**'
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Controller version (e.g., 0.2.0)'
+        required: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install mkdocs-material mike
+
+      - name: Copy shared CSS to stylesheets
+        run: cp docs/shared/colors.css docs/controller/docs/stylesheets/
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy with mike
+        env:
+          PAGES_TOKEN: ${{ secrets.PAGES_REPO_TOKEN }}
+        run: |
+          # Clone target repo
+          git clone https://x-access-token:${PAGES_TOKEN}@github.com/HAProxy-Template-IC/haproxy-template-ic.github.io.git pages-repo
+          cd pages-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Copy mkdocs config to target repo
+          cp -r ../docs/controller/mkdocs.yml .
+          cp -r ../docs/controller/docs docs
+
+          VERSION="${{ steps.version.outputs.version }}"
+          if [ "$VERSION" = "dev" ]; then
+            # Check if any non-dev versions exist
+            if [ -f controller/versions.json ] && jq -e '.[] | select(.version != "dev")' controller/versions.json > /dev/null 2>&1; then
+              # Other releases exist, don't alias dev as latest
+              mike deploy --push \
+                --deploy-prefix controller \
+                --branch main \
+                "$VERSION"
+            else
+              # No releases yet, alias dev as latest
+              mike deploy --push --update-aliases \
+                --deploy-prefix controller \
+                --branch main \
+                "$VERSION" latest
+            fi
+          else
+            mike deploy --push --update-aliases \
+              --deploy-prefix controller \
+              --branch main \
+              "$VERSION" latest
+          fi
+
+      - name: Update landing page and shared assets
+        env:
+          PAGES_TOKEN: ${{ secrets.PAGES_REPO_TOKEN }}
+        run: |
+          cd pages-repo
+          # Reset to clean state after mike's push to avoid including stale changes
+          git fetch origin
+          git reset --hard origin/main
+          # Deploy shared CSS
+          mkdir -p shared
+          cp ../docs/shared/colors.css shared/
+          # Deploy landing page
+          cp ../docs/landing-page/index.html index.html
+          git add index.html shared/
+          if ! git diff --cached --quiet; then
+            git commit -m "Update landing page and shared assets"
+            git push origin main
+          fi

--- a/.github/workflows/docs-helm-chart.yaml
+++ b/.github/workflows/docs-helm-chart.yaml
@@ -1,0 +1,101 @@
+name: Deploy Helm Chart Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/haptic/docs/**'
+      - 'charts/haptic/mkdocs.yml'
+    tags:
+      - 'helm-chart-*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Chart version (e.g., 0.3.0)'
+        required: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install mkdocs-material mike
+
+      - name: Copy shared CSS to stylesheets
+        run: cp docs/shared/colors.css charts/haptic/docs/stylesheets/
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/helm-chart-* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/helm-chart-}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy with mike
+        env:
+          PAGES_TOKEN: ${{ secrets.PAGES_REPO_TOKEN }}
+        run: |
+          # Clone target repo
+          git clone https://x-access-token:${PAGES_TOKEN}@github.com/HAProxy-Template-IC/haproxy-template-ic.github.io.git pages-repo
+          cd pages-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Copy mkdocs config to target repo
+          cp -r ../charts/haptic/mkdocs.yml .
+          cp -r ../charts/haptic/docs docs
+
+          VERSION="${{ steps.version.outputs.version }}"
+          if [ "$VERSION" = "dev" ]; then
+            # Check if any non-dev versions exist
+            if [ -f helm-chart/versions.json ] && jq -e '.[] | select(.version != "dev")' helm-chart/versions.json > /dev/null 2>&1; then
+              # Other releases exist, don't alias dev as latest
+              mike deploy --push \
+                --deploy-prefix helm-chart \
+                --branch main \
+                "$VERSION"
+            else
+              # No releases yet, alias dev as latest
+              mike deploy --push --update-aliases \
+                --deploy-prefix helm-chart \
+                --branch main \
+                "$VERSION" latest
+            fi
+          else
+            mike deploy --push --update-aliases \
+              --deploy-prefix helm-chart \
+              --branch main \
+              "$VERSION" latest
+          fi
+
+      - name: Deploy shared assets
+        env:
+          PAGES_TOKEN: ${{ secrets.PAGES_REPO_TOKEN }}
+        run: |
+          cd pages-repo
+          git fetch origin
+          git reset --hard origin/main
+          mkdir -p shared
+          cp ../docs/shared/colors.css shared/
+          git add shared/
+          if ! git diff --cached --quiet; then
+            git commit -m "Update shared assets"
+            git push origin main
+          fi


### PR DESCRIPTION
The CI workflow files were lost when GitLab mirror pushes overwrote the main branch (CI has been broken since 2025-12-02). This restores all four workflows (ci.yml, chart.yaml, docs-controller.yaml, docs-helm-chart.yaml) with updates to reflect the project rename from haproxy-template-ic to haptic:

- Go version: 1.25 -> 1.26 (matching go.mod requires go 1.26.1)
- Chart path: charts/haproxy-template-ic -> charts/haptic
- CRD domain: haproxy-template-ic.github.io -> haproxy-haptic.org
- Controller binary: bin/controller -> bin/haptic-controller
- Docker image tag: haproxy-template-ic:test -> haptic:test (matching ControllerImageName constant)
- Kind cluster name: haproxy-template-ic-dev -> haptic-dev
- Install all 3 required CRDs instead of just haproxytemplateconfigs

The original audit failure was caused by a Go vulnerability in a dependency that has since been resolved by Renovate updates. The acceptance test failure (shard 1/4) was caused by the CI loading the image with the wrong name (haproxy-template-ic:test vs the expected haptic:test) and installing only one CRD when three are required.