### PR TITLE
fix: add missing packages to golangci-lint targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,18 @@ lint: vendor ## Run all linters (YAML, JSON, Markdown, Go)
 	@echo "Running golangci-lint..."
 ifdef CI
 	$(GOLANGCI_LINT) run --output.code-climate.path=gl-code-quality-report.json \
-		./cmd/... ./examples/... ./pkg/apis/... ./pkg/controller/... \
-		./pkg/core/... ./pkg/dataplane/... ./pkg/events/... ./pkg/k8s/... \
-		./pkg/stores/... ./pkg/templating/... ./pkg/webhook/... ./tests/... ./tools/...
+		./cmd/... ./examples/... ./pkg/apis/... ./pkg/compression/... \
+		./pkg/controller/... ./pkg/core/... ./pkg/dataplane/... ./pkg/events/... \
+		./pkg/httpstore/... ./pkg/introspection/... ./pkg/k8s/... ./pkg/lifecycle/... \
+		./pkg/metrics/... ./pkg/stores/... ./pkg/templating/... ./pkg/webhook/... \
+		./tests/... ./tools/...
 else
 	$(GOLANGCI_LINT) run \
-		./cmd/... ./examples/... ./pkg/apis/... ./pkg/controller/... \
-		./pkg/core/... ./pkg/dataplane/... ./pkg/events/... ./pkg/k8s/... \
-		./pkg/stores/... ./pkg/templating/... ./pkg/webhook/... ./tests/... ./tools/...
+		./cmd/... ./examples/... ./pkg/apis/... ./pkg/compression/... \
+		./pkg/controller/... ./pkg/core/... ./pkg/dataplane/... ./pkg/events/... \
+		./pkg/httpstore/... ./pkg/introspection/... ./pkg/k8s/... ./pkg/lifecycle/... \
+		./pkg/metrics/... ./pkg/stores/... ./pkg/templating/... ./pkg/webhook/... \
+		./tests/... ./tools/...
 endif
 	@echo "Running arch-go..."
 	$(ARCH_GO)
@@ -82,7 +86,11 @@ endif
 
 lint-fix: ## Run golangci-lint with auto-fix
 	@echo "Running golangci-lint with auto-fix..."
-	$(GOLANGCI_LINT) run --fix ./cmd/... ./examples/... ./pkg/apis/... ./pkg/controller/... ./pkg/core/... ./pkg/dataplane/... ./pkg/events/... ./pkg/k8s/... ./pkg/stores/... ./pkg/templating/... ./pkg/webhook/... ./tests/... ./tools/...
+	$(GOLANGCI_LINT) run --fix ./cmd/... ./examples/... ./pkg/apis/... ./pkg/compression/... \
+		./pkg/controller/... ./pkg/core/... ./pkg/dataplane/... ./pkg/events/... \
+		./pkg/httpstore/... ./pkg/introspection/... ./pkg/k8s/... ./pkg/lifecycle/... \
+		./pkg/metrics/... ./pkg/stores/... ./pkg/templating/... ./pkg/webhook/... \
+		./tests/... ./tools/...
 
 ## Chart linting
 


### PR DESCRIPTION
The golangci-lint package lists in the `lint`, `lint` (CI variant), and `lint-fix` Makefile targets were missing five packages that are present in `COVERAGE_PACKAGES`: `compression`, `httpstore`, `introspection`, `lifecycle`, and `metrics`. This means these packages were tested but never linted, so any lint violations in them would go undetected.

This adds all five missing packages to the three golangci-lint invocations to match the coverage scope.